### PR TITLE
Unify hero typography & CTA (Home ⇄ Services) via global toggle

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -5152,3 +5152,84 @@ main[data-template="page.coaching"] [id$="custom_liquid_calendly"] .calendly-inl
     height: 1000px !important;    /* room for Calendly mobile layout */
   }
 }
+
+/* ==========================================================
+   NIBANA — Global hero typography & CTA sync (scoped)
+   Scope: only when the site toggle adds `nb-typography` to <body>.
+   No changes to images, videos or backgrounds.
+   ========================================================== */
+body.nb-typography {
+  /* nothing here — all rules are scoped below */
+}
+
+/* HERO text (Service) → use the same global variables as Home */
+body.nb-typography .nb-hero-skit .nb-skit__copy .nb-h1 {
+  /* Map to theme H1 tokens (same ones Home hero uses) */
+  font-family: var(--font-h1--family);
+  font-style: var(--font-h1--style);
+  font-weight: var(--font-h1--weight);
+  font-size: var(--font-h1--size);
+  line-height: var(--font-h1--line-height);
+  letter-spacing: var(--font-h1--letter-spacing);
+  text-transform: var(--font-h1--case);
+  color: inherit; /* defer to scheme; overrides any custom color */
+  margin: 0 0 .25em;
+}
+
+body.nb-typography .nb-hero-skit .nb-skit__copy .nb-sub {
+  /* Map subhead to paragraph tokens for consistency */
+  font-family: var(--font-paragraph--family);
+  font-style: var(--font-paragraph--style, normal);
+  font-weight: var(--font-paragraph--weight, var(--font-weight));
+  font-size: var(--font-paragraph--size);
+  line-height: var(--font-paragraph--line-height);
+  color: var(--color-foreground);
+  opacity: var(--opacity-80);
+  margin: 0 0 1rem;
+}
+
+body.nb-typography .nb-hero-skit .nb-skit__copy .nb-eyebrow {
+  /* Eyebrow feels like small heading: use H6 tokens */
+  font-family: var(--font-h6--family, var(--font-paragraph--family));
+  font-style: var(--font-h6--style, normal);
+  font-weight: var(--font-h6--weight, 600);
+  font-size: var(--font-h6--size, var(--font-size--xs));
+  line-height: var(--font-h6--line-height, 1.2);
+  letter-spacing: var(--font-h6--letter-spacing, .08em);
+  text-transform: var(--font-h6--case, uppercase);
+  color: var(--color-foreground);
+  opacity: var(--opacity-60);
+  margin: 0 0 .5rem;
+}
+
+/* CTA in Service Hero → match theme primary button look */
+body.nb-typography .nb-hero-skit .nb-skit__copy .nb-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  font-family: var(--button-font-family-primary);
+  font-weight: var(--button-font-weight-primary);
+  text-transform: var(--button-text-case-primary);
+
+  padding: var(--button-padding-block) var(--button-padding-inline);
+  border-radius: var(--style-border-radius-buttons-primary);
+  border: var(--button-border-width, 0) solid var(--color-primary-button-border);
+
+  background: var(--color-primary-button);
+  color: var(--color-primary-button-text);
+  box-shadow: var(--shadow-button);
+  text-decoration: none;
+}
+body.nb-typography .nb-hero-skit .nb-skit__copy .nb-cta:hover {
+  background: var(--color-primary-button-hover-background);
+  color: var(--color-primary-button-hover-text);
+  border-color: var(--color-primary-button-hover-border);
+}
+
+/* Optional: unify Home hero CTA too (without touching other buttons) */
+body.nb-typography .hero .button,
+body.nb-typography .hero .button:not(.button-secondary, .button-unstyled) {
+  border-radius: var(--style-border-radius-buttons-primary);
+  box-shadow: var(--shadow-button);
+}

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -324,6 +324,13 @@
     "name": "t:names.typography",
     "settings": [
       {
+  "type": "checkbox",
+  "id": "enable_nb_typography",
+  "label": "Use Nibana typography & CTAs sitewide",
+  "default": true,
+  "info": "Makes headings/subheads/eyebrows + CTA buttons use the same look as the Home hero. No changes to images, videos or backgrounds."
+}
+      {
         "type": "header",
         "content": "t:content.fonts"
       },

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -140,7 +140,7 @@ Runs only when template = page.book-call.
 
   </head>
 
-  <body class="page-width-{{ settings.page_width }} card-hover-effect-{{ settings.card_hover_effect }}">
+  <body class="page-width-{{ settings.page_width }} card-hover-effect-{{ settings.card_hover_effect }}{% if settings.enable_nb_typography %} nb-typography{% endif %}">
     {% render 'skip-to-content-link', href: '#MainContent', text: 'accessibility.skip_to_text' %}
     <div id="header-group">
       {% sections 'header-group' %}


### PR DESCRIPTION
No media/background changes; service hero now inherits Home’s H1/subhead/eyebrow + CTA look. Toggle is in Theme settings → Typography → “Use Nibana typography & CTAs sitewide.”