### PR TITLE
Header polish: readable mega-menu + caret only for parents

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -751,6 +751,16 @@ capture actions
   .header .mega-menu__content li{ margin-bottom: 6px; }
 }
 
+/* Force dark ink inside the white mega menu panel even when header is inverse */
+.header .header-menu .mega-menu { color: #223238; }
+.header .header-menu .mega-menu__link { color: #223238; }
+
+.header .header-menu .mega-menu__link:hover,
+.header .header-menu .mega-menu__link:focus-visible {
+  /* keep your soft hover */
+  background: color-mix(in oklab, #223238, #fff 92%);
+}
+
 {% endstylesheet %}
 
 {% schema %}


### PR DESCRIPTION
	•	Force ink color for mega-menu links so Services panel is readable on white.
	•	Restrict caret + expander behavior to items with a real mega panel.
	•	Optional transition for flicker-free open/close.
	•	No changes to mobile drawer behavior.