### PR TITLE
Header: only show caret for submenu items + mega overlay hardening

### DIFF
--- a/assets/header-menu.js
+++ b/assets/header-menu.js
@@ -2,8 +2,8 @@ import { Component } from '@theme/component';
 import { debounce, onDocumentReady } from '@theme/utilities';
 import { MegaMenuHoverEvent } from '@theme/events';
 
-const ACTIVATE_DELAY = 0;
-const DEACTIVATE_DELAY = 350;
+const ACTIVATE_DELAY = 60;  // a tiny delay helps smoothness without feeling laggy
+const DEACTIVATE_DELAY = 300;
 
 /**
  * A custom element that manages a header menu.
@@ -19,7 +19,6 @@ const DEACTIVATE_DELAY = 350;
  */
 class HeaderMenu extends Component {
   requiredRefs = ['overflowMenu'];
-
   #abortController = new AbortController();
 
   connectedCallback() {
@@ -29,11 +28,6 @@ class HeaderMenu extends Component {
       signal: this.#abortController.signal,
     });
 
-    // Flag only real panel parents (adds .has-panel and aria-expanded="false")
-    // Run once now and again after DOM is ready to catch slotting.
-    this.#flagRealToggles();
-    onDocumentReady(this.#flagRealToggles);
-
     onDocumentReady(this.#preloadImages);
   }
 
@@ -42,67 +36,60 @@ class HeaderMenu extends Component {
     this.#abortController.abort();
   }
 
-  /**
-   * @type {State}
-   */
-  #state = {
-    activeItem: null,
-  };
+  /** @type {State} */
+  #state = { activeItem: null };
 
-  /**
-   * Time to allow for a closing animation between initiating a deactivation and actually deactivating the active item.
-   * @returns {number}
-   */
+  /** Time to allow for a closing animation between initiating a deactivation and actually deactivating the active item. */
   get animationDelay() {
     const value = this.dataset.animationDelay;
     return value ? parseInt(value, 10) : 0;
   }
 
-  /**
-   * Get the overflow menu
-   */
+  /** The overflow menu element inside the custom element’s shadow */
   get overflowMenu() {
     return /** @type {HTMLElement | null} */ (this.refs.overflowMenu?.shadowRoot?.querySelector('[part="overflow"]'));
   }
 
-  /**
-   * Whether the overflow menu is hovered
-   * @returns {boolean}
-   */
+  /** Is the overflow menu currently hovered? */
   get overflowHovered() {
     return this.refs.overflowMenu?.matches(':hover') ?? false;
   }
 
-  /**
-   * Activate the selected menu item immediately
-   * @param {PointerEvent | FocusEvent} event
-   */
+  /** Activate the selected menu item (public handler used by the template) */
   activate = (event) => {
     this.#debouncedDeactivate.cancel();
     this.#debouncedActivateHandler.cancel();
-
     this.#debouncedActivateHandler(event);
   };
 
-  /**
-   * Activate the selected menu item with a delay
-   * @param {PointerEvent | FocusEvent} event
-   */
+  /** Internal: activate after a small delay */
   #activateHandler = (event) => {
     this.#debouncedDeactivate.cancel();
-
     this.dispatchEvent(new MegaMenuHoverEvent());
-
     this.removeAttribute('data-animating');
 
     if (!(event.target instanceof Element)) return;
 
-    let item = findMenuItem(event.target);
-    if (!item || item == this.#state.activeItem) return;
+    const item = findMenuItem(event.target);
+    if (!item || item === this.#state.activeItem) return;
 
-    const isDefaultSlot = event.target.slot === '';
-    this.dataset.overflowExpanded = (!isDefaultSlot).toString();
+    const isDefaultSlot = event.target.slot === ''; // true for normal top-level items
+    let submenu = findSubmenu(item);
+    const overflowMenuHeight = this.overflowMenu?.offsetHeight ?? 0;
 
+    // If we're hovering the “More” item, use the overflow panel as the submenu
+    if (!submenu && !isDefaultSlot) {
+      submenu = this.overflowMenu;
+    }
+
+    // 🔒 No submenu? Do not enter expanded state. Also ensure overlay is closed.
+    if (!submenu) {
+      this.dataset.overflowExpanded = 'false';
+      this.#deactivate(this.#state.activeItem);
+      return;
+    }
+
+    // There *is* a submenu: proceed to expand
     const previouslyActiveItem = this.#state.activeItem;
     if (previouslyActiveItem) previouslyActiveItem.ariaExpanded = 'false';
 
@@ -110,45 +97,26 @@ class HeaderMenu extends Component {
     this.ariaExpanded = 'true';
     item.ariaExpanded = 'true';
 
-    let submenu = findSubmenu(item);
-    let overflowMenuHeight = this.overflowMenu?.offsetHeight ?? 0;
-
-    if (!submenu && !isDefaultSlot) {
-      submenu = this.overflowMenu;
-    }
-
-    const submenuHeight = submenu ? Math.max(submenu.offsetHeight, overflowMenuHeight) : 0;
-
+    const submenuHeight = Math.max(submenu.offsetHeight, overflowMenuHeight);
+    this.dataset.overflowExpanded = (!isDefaultSlot).toString();
     this.style.setProperty('--submenu-height', `${submenuHeight}px`);
     this.style.setProperty('--submenu-opacity', '1');
   };
 
   #debouncedActivateHandler = debounce(this.#activateHandler, ACTIVATE_DELAY);
 
-  /**
-   * Deactivate the active item after a delay
-   * @param {PointerEvent | FocusEvent} event
-   */
+  /** Deactivate the active item after a delay (public handler used by template) */
   deactivate(event) {
     this.#debouncedActivateHandler.cancel();
-
     if (!(event.target instanceof Element)) return;
 
     const item = findMenuItem(event.target);
-
-    // Make sure the item to be deactivated is still the active one. Ideally
-    // we cancelled the debounce before the item was changed, but just in case.
-    if (item === this.#state.activeItem) {
-      this.#debouncedDeactivate();
-    }
+    if (item === this.#state.activeItem) this.#debouncedDeactivate();
   }
 
-  /**
-   * Deactivate the active item immediately
-   * @param {HTMLElement | null} [item]
-   */
+  /** Internal: close immediately */
   #deactivate = (item = this.#state.activeItem) => {
-    if (!item || item != this.#state.activeItem) return;
+    if (!item || item !== this.#state.activeItem) return;
     if (this.overflowHovered) return;
 
     this.style.setProperty('--submenu-height', '0px');
@@ -160,48 +128,15 @@ class HeaderMenu extends Component {
     item.ariaExpanded = 'false';
     item.setAttribute('data-animating', '');
 
-    setTimeout(
-      () => {
-        item.removeAttribute('data-animating');
-      },
-      Math.max(0, this.animationDelay - 150)
-    ); // Start header transition 150ms before submenu finishes
+    setTimeout(() => item.removeAttribute('data-animating'), Math.max(0, this.animationDelay - 150));
   };
 
-  /**
-   * Deactivate the active item after a delay
-   * @param {PointerEvent | FocusEvent} event
-   */
   #debouncedDeactivate = debounce(this.#deactivate, DEACTIVATE_DELAY);
 
-  /**
-   * Preload images that are set to load lazily.
-   */
+  /** Preload lazy images in the header so the mega doesn’t flash in late */
   #preloadImages = () => {
     const images = this.querySelectorAll('img[loading="lazy"]');
     images?.forEach((image) => image.removeAttribute('loading'));
-  };
-
-  /**
-   * Mark only the true mega-menu parents.
-   * - Adds .has-panel and aria-expanded="false" to items that own a submenu
-   * - Removes aria-expanded and .has-panel from items that don't
-   */
-  #flagRealToggles = () => {
-    /** @type {HTMLElement[]} */
-    const links = Array.from(this.querySelectorAll('[ref="menuitem"]'));
-
-    links.forEach((link) => {
-      const hasPanel = !!findSubmenu(link);
-
-      if (hasPanel) {
-        link.classList.add('has-panel');
-        if (!link.hasAttribute('aria-expanded')) link.setAttribute('aria-expanded', 'false');
-      } else {
-        link.classList.remove('has-panel');
-        link.removeAttribute('aria-expanded');
-      }
-    });
   };
 }
 
@@ -209,76 +144,44 @@ if (!customElements.get('header-menu')) {
   customElements.define('header-menu', HeaderMenu);
 }
 
-/**
- * Find the closest menu item.
- * @param {Element | null | undefined} element
- * @returns {HTMLElement | null}
- */
+/** Find the closest menu item element */
 function findMenuItem(element) {
   if (!(element instanceof Element)) return null;
 
   if (element?.matches('[slot="more"]')) {
-    // Select the first overflowing menu item when hovering over the "More" item
+    // Hovering the “More” trigger → select the first overflowing item’s menuitem
     return findMenuItem(element.parentElement?.querySelector('[slot="overflow"]'));
   }
-
   return element?.querySelector('[ref="menuitem"]');
 }
 
-/**
- * Find the closest submenu.
- * @param {Element | null | undefined} element
- * @returns {HTMLElement | null}
- */
+/** Find the submenu associated to a menu item */
 function findSubmenu(element) {
   const submenu = element?.parentElement?.querySelector('[ref="submenu[]"]');
   return submenu instanceof HTMLElement ? submenu : null;
 }
 
-/* === NB: Class toggle for desktop mega overlay (scrim) === */
+/* === NB: Class toggle for desktop mega overlay (to dim the hero) === */
 (function () {
   var desktopMQ = window.matchMedia('(min-width: 990px)');
   var header = document.querySelector('header');
   if (!header) return;
 
   var openClass = 'nb-mega-open';
-  var overCount = 0; // avoid flicker crossing sub-elements
+  var overCount = 0;
 
-  function enable() {
-    if (!desktopMQ.matches) return;
-    document.documentElement.classList.add(openClass);
-  }
-  function disable() {
-    if (!desktopMQ.matches) return;
-    document.documentElement.classList.remove(openClass);
-  }
+  function enable(){ if (desktopMQ.matches) document.documentElement.classList.add(openClass); }
+  function disable(){ if (desktopMQ.matches) document.documentElement.classList.remove(openClass); }
 
-  header.addEventListener(
-    'mouseenter',
-    function (e) {
-      var el = e.target.closest('[data-header-nav-popover], .mega-menu, .header__inline-menu');
-      if (el) {
-        overCount++;
-        enable();
-      }
-    },
-    true
-  );
+  header.addEventListener('mouseenter', function (e) {
+    var el = e.target.closest('[data-header-nav-popover], .mega-menu, .header__inline-menu');
+    if (el) { overCount++; enable(); }
+  }, true);
 
-  header.addEventListener(
-    'mouseleave',
-    function (e) {
-      var el = e.target.closest('[data-header-nav-popover], .mega-menu, .header__inline-menu');
-      if (el) {
-        overCount = Math.max(0, overCount - 1);
-        if (overCount === 0) disable();
-      }
-    },
-    true
-  );
+  header.addEventListener('mouseleave', function (e) {
+    var el = e.target.closest('[data-header-nav-popover], .mega-menu, .header__inline-menu');
+    if (el) { overCount = Math.max(0, overCount - 1); if (overCount === 0) disable(); }
+  }, true);
 
-  // Close on Esc as a nicety
-  document.addEventListener('keydown', function (e) {
-    if (e.key === 'Escape') disable();
-  });
+  document.addEventListener('keydown', function (e) { if (e.key === 'Escape') disable(); });
 })();

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -729,6 +729,15 @@ capture actions
   display: none !important;
 }
 
+/* NB: Hide carets for items without submenus — even when aria-expanded changes */
+.header__menu-item [data-caret]{ display:none !important; }
+.header__menu-item:has([ref="submenu[]"]) [data-caret]{ display:inline-flex !important; }
+
+/* extra guard: if something sets aria-expanded=true on a no-submenu item, still hide */
+.header__menu-item[aria-expanded="true"]:not(:has([ref="submenu[]"])) [data-caret]{
+  display:none !important;
+}
+
 /* 2.4 Active page underline (subtle, thicker) */
 .menu-list__item[aria-current] > .menu-list__link{ position: relative; }
 .menu-list__item[aria-current] > .menu-list__link::before{


### PR DESCRIPTION
Resolves caret reappearing on non-submenu items; eliminates overlay open on simple links; keeps hero dimming only for real megamenu.