### PR TITLE
Fix mega menu strap: target hyphenated submenu classes + lock transparent header

### DIFF
--- a/assets/header-menu.js
+++ b/assets/header-menu.js
@@ -69,18 +69,19 @@ class HeaderMenu extends Component {
       const style = document.createElement('style');
       style.id = 'nb-overflow-patch';
       style.textContent = `
-        /* kill the full-width strap behind the white panel */
-        .menu_list__submenu {
-          background: transparent !important;
-          box-shadow: none !important;
-          border: 0 !important;
-          --color-background: 0 0 0;
-          --opacity-background: 0;
-          --shadow-opacity: 0;
-          backdrop-filter: none !important;
-          -webkit-backdrop-filter: none !important;
-        }
-      `;
+  /* kill the full-width strap behind the white panel */
+  .menu_list__submenu,
+  .menu-list__submenu {
+    background: transparent !important;
+    box-shadow: none !important;
+    border: 0 !important;
+    --color-background: 0 0 0;
+    --opacity-background: 0;
+    --shadow-opacity: 0;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+  }
+`;
       host.shadowRoot.appendChild(style);
     } else {
       // no-op; already patched
@@ -90,8 +91,11 @@ class HeaderMenu extends Component {
   /** Also clear any light-DOM strap (some presets render it outside shadow) */
   #clearLightDOMStrap = () => {
     const nodes = this.querySelectorAll(
-      '[data-header-nav-popover], .menu_list__submenu, .menu_list__submenu-inner'
-    );
+  '[data-header-nav-popover], \
+  .menu_list__submenu, .menu_list__submenu-inner, \
+  .menu-list__submenu, .menu-list__submenu-inner, \
+  .header__submenu, .mega-menu__content'
+);
     nodes.forEach((el) => {
       el.style.setProperty('background', 'transparent', 'important');
       el.style.setProperty('box-shadow', 'none', 'important');

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -861,11 +861,15 @@ body:has(> #header-group > header-component) {
 /* === NB: Remove the dark full-width "strap" behind the Services card ==== */
 @media (min-width: 990px){
   /* the strap/wrapper layer */
-  .header__submenu,
-  .header__submenu::before,
-  .header__submenu::after,
-  .mega-menu__content,
-  .header__submenu .header__submenu-content {
+  header-component .header__inline-menu::after,
+  header-component .header__submenu,
+  header-component .header__submenu::before,
+  header-component .header__submenu::after,
+  header-component .menu-list__submenu,
+  header-component .menu-list__submenu::before,
+  header-component .menu-list__submenu::after,
+  header-component .menu-list__submenu-inner,
+  header-component .mega-menu__content {
     background: transparent !important;
     backdrop-filter: none !important;
     -webkit-backdrop-filter: none !important;
@@ -874,6 +878,7 @@ body:has(> #header-group > header-component) {
   }
 
   /* if any rule tries to inject a background inline */
+  nav[header-menu] .menu-list__submenu[style*="background"],
   .header__submenu[style*="background"] { background: transparent !important; }
 }
 


### PR DESCRIPTION
	•	Neutralize full-width background on desktop by targeting .menu-list__submenu / ...-inner (hyphen variant).
	•	Keep existing underscore selectors for safety.
	•	Reinforce transparent header rows when menu is open/focused.
	•	No visual regressions; Services panel remains a white card only.