### PR TITLE
Services dropdown — luxe polish (tray, hover/focus pill, optional current state)

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -823,16 +823,6 @@ body.is-mega-closing header-component .mega-menu__content {
   header-component .nb-cta { display: none !important; }
 }
 
-/* Desktop dropdown surface = light brand sage (instead of white) */
-@media (min-width: 990px){
-  #shopify-section-{{ section.id }} header-component .header-menu .mega-menu{
-    background: var(--nb-sage-surface) !important;
-    color: var(--nb-deep) !important;
-    border: 1px solid color-mix(in oklab, var(--nb-deep), #fff 88%) !important;
-    box-shadow: 0 18px 46px rgba(15,91,89,.12) !important; /* cool, brand-tinted shadow */
-  }
-}
-
 /* Dynamic width: grow to fit the longest item label, within sensible bounds */
 @media (min-width: 990px){
   #shopify-section-{{ section.id }} header-component .header-menu .mega-menu{
@@ -850,13 +840,17 @@ body.is-mega-closing header-component .mega-menu__content {
   }
 }
 
-/* Desktop dropdown surface = light brand sage (instead of white) */
+/* Desktop dropdown surface — luxe tray */
 @media (min-width: 990px){
   #shopify-section-{{ section.id }} header-component .header-menu .mega-menu{
     background: var(--nb-sage-surface, #F7FAF9) !important;
     color: var(--nb-deep, #0F5B59) !important;
+    border-radius: 16px !important; /* softer corners */
     border: 1px solid color-mix(in oklab, var(--nb-deep, #0F5B59), #fff 88%) !important;
-    box-shadow: 0 18px 46px rgba(15,91,89,.12) !important;
+    /* airier, longer shadow with brand tint */
+    box-shadow:
+      0 2px 6px rgba(15,91,89,.04),
+      0 24px 60px rgba(15,91,89,.14) !important;
   }
 }
 
@@ -871,6 +865,57 @@ header-component header-menu .menu-list__link[aria-expanded="true"]{
 @media (min-width: 990px){
   body:not(.is-mega-open):not(.is-mega-closing) header-component[data-sticky-state="active"] .header__row{
     box-shadow: 0 1px 0 color-mix(in oklab, var(--nb-deep, #0F5B59), #fff 88%);
+  }
+}
+
+/* Luxe item hover/focus — silk highlight pill */
+@media (min-width: 990px){
+  #shopify-section-{{ section.id }} .header-menu .mega-menu__list{
+    padding: 10px;            /* gives the pill a little breathing room */
+    gap: 2px;
+  }
+
+  #shopify-section-{{ section.id }} .header-menu .mega-menu__link{
+    border-radius: 12px;
+    padding: 10px 14px;
+    line-height: 1.35;
+    transition:
+      color .18s ease,
+      background-color .18s ease,
+      transform .18s ease,
+      box-shadow .18s ease;
+  }
+
+  /* hover + keyboard focus */
+  #shopify-section-{{ section.id }} .header-menu .mega-menu__link:hover,
+  #shopify-section-{{ section.id }} .header-menu .mega-menu__link:focus-visible{
+    background: color-mix(in oklab, var(--nb-sage-surface, #F7FAF9), #fff 28%);
+    box-shadow:
+      0 0 0 1px color-mix(in oklab, var(--nb-deep, #0F5B59), #fff 85%) inset,
+      0 10px 26px rgba(15,91,89,.10);
+    transform: translateY(-1px);
+    outline: none;
+  }
+
+  /* precise focus ring for accessibility */
+  #shopify-section-{{ section.id }} .header-menu .mega-menu__link:focus-visible{
+    box-shadow:
+      0 0 0 2px color-mix(in oklab, var(--nb-deep, #0F5B59), #fff 70%) inset,
+      0 12px 28px rgba(15,91,89,.12);
+  }
+
+  /* optional: current page highlight (keeps it calmer than hover) */
+  #shopify-section-{{ section.id }} .header-menu .mega-menu__link[aria-current="page"],
+  #shopify-section-{{ section.id }} .header-menu .mega-menu__link[aria-current="true"]{
+    background: color-mix(in oklab, var(--nb-sage-surface, #F7FAF9), #fff 15%);
+    box-shadow: 0 0 0 1px color-mix(in oklab, var(--nb-deep, #0F5B59), #fff 88%) inset;
+  }
+
+  /* respect reduced motion */
+  @media (prefers-reduced-motion: reduce){
+    #shopify-section-{{ section.id }} .header-menu .mega-menu__link{
+      transition: none;
+    }
   }
 }
 

--- a/snippets/mega-menu-list.liquid
+++ b/snippets/mega-menu-list.liquid
@@ -101,27 +101,32 @@
       </a>
       {% if link.links != blank %}
         <ul
-          class="list-unstyled"
-          {% if should_break_columns %}
-            style="column-count: {{ column_span }};"
-          {% endif %}
-        >
-          {% for childLink in link.links %}
-            {% assign break_after_modulo = forloop.index | modulo: links_before_wrap %}
-            <li
-              {% if break_after_modulo == 0 and should_break_columns %}
-                style="break-after: column;"
-              {% endif %}
-            >
-              <a
-                href="{{ childLink.url }}"
-                class="mega-menu__link"
-              >
-                <span class="mega-menu__link-title">{{- childLink.title -}}</span>
-              </a>
-            </li>
-          {% endfor %}
-        </ul>
+  class="list-unstyled"
+  role="menu"
+  aria-label="{{ link.title | escape }}"
+  {% if should_break_columns %}
+    style="column-count: {{ column_span }};"
+  {% endif %}
+>
+  {% for childLink in link.links %}
+    {% assign break_after_modulo = forloop.index | modulo: links_before_wrap %}
+    <li
+      role="none"
+      {% if break_after_modulo == 0 and should_break_columns %}
+        style="break-after: column;"
+      {% endif %}
+    >
+      <a
+        href="{{ childLink.url }}"
+        class="mega-menu__link"
+        role="menuitem"
+        {% if childLink.current or childLink.active %}aria-current="page"{% endif %}
+      >
+        <span class="mega-menu__link-title">{{- childLink.title -}}</span>
+      </a>
+    </li>
+  {% endfor %}
+</ul>
       {% endif %}
     </div>
 


### PR DESCRIPTION
Softer tray radius + deeper brand-tinted shadow.
Silk hover/focus pill with inset ring; reduced-motion safe.
Add role="menu" + aria-label to each submenu <ul>.
Add role="menuitem" to submenu anchors and role="none" to their wrapping <li>s.
Set aria-current="page" on the active link so the optional “current page” style can apply.