### PR TITLE
Add reading time to blog cards (grid + related)

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -5348,3 +5348,14 @@ body.nb-typography{
 .footer [data-footer-products],
 .footer a[href*="/products"],
 .footer a[href*="/collections"] { display: none !important; }
+
+/* Blog meta: reading time separator + tone */
+.rt-sep{ opacity:.45; margin:0 .35rem; }
+.rt{ opacity:.75; }
+
+/* Subtle hairline above footer utilities */
+.footer .footer-utilities{
+  border-top: 1px solid color-mix(in oklab, var(--nb-deep, #0F5B59), #fff 88%);
+  padding-top: 12px;
+}
+

--- a/blocks/_blog-post-card.liquid
+++ b/blocks/_blog-post-card.liquid
@@ -29,10 +29,26 @@
     </div>
   {%- endif -%}
 
-  <div class="blog-post-card__content">
+    <div class="blog-post-card__content">
     <a href="{{ article.url }}">{{ title }}</a>
 
-    {{ details }}
+    {%- liquid
+      assign _w = article.content | strip_html | split: ' ' | size
+      assign _m = _w | divided_by: 200
+      assign _r = _w | modulo: 200
+      if _r > 0
+        assign _m = _m | plus: 1
+      endif
+      if _m < 1
+        assign _m = 1
+      endif
+    -%}
+
+    <div class="blog-post-card__meta">
+      {{ details }}
+      <span class="blog-post-card__sep" aria-hidden="true">·</span>
+      <span class="blog-post-card__read">{{ _m }} min read</span>
+    </div>
 
     {{ description }}
   </div>
@@ -101,6 +117,12 @@
   .blog-post-card__content a:hover [style*='--color: var(--color-foreground)'] {
     color: rgb(var(--color-foreground-rgb) / var(--opacity-subdued-text));
   }
+
+  /* Blog micro-upgrade: reading minutes on cards */
+  .blog-post-card__meta { color: rgb(var(--color-foreground-rgb) / var(--opacity-subdued-text)); font-size: var(--font-size--body-sm); }
+  .blog-post-card__meta > * { display: inline; margin: 0; }
+  .blog-post-card__sep { margin: 0 .4em; }
+
 {% endstylesheet %}
 
 {% schema %}

--- a/sections/main-blog-post.liquid
+++ b/sections/main-blog-post.liquid
@@ -126,57 +126,79 @@
       </div>
     </section>
 
-    {%- comment -%} === Related posts (by shared tags; fallback to recent) === {%- endcomment -%}
-    {%- assign _shown = 0 -%}
-    {%- capture related_markup -%}
-      <div class="nb-related__grid">
-      {%- for a in blog.articles -%}
-        {%- if a.id != article.id and _shown < 3 -%}
-          {%- assign _overlap = false -%}
-          {%- for t in article.tags -%}
-            {%- if a.tags contains t -%}{%- assign _overlap = true -%}{%- endif -%}
-          {%- endfor -%}
-          {%- if _overlap -%}
-            <article class="nb-related__card">
-              <a class="nb-related__link" href="{{ a.url }}">
-                {%- if a.image -%}
-                  {{ a | image_url: width: 800 | image_tag: alt: a.title, class: 'nb-related__img', sizes: '(max-width: 740px) 100vw, 360px', widths: '360,540,720,800' }}
-                {%- endif -%}
-                <h4 class="nb-related__title">{{ a.title }}</h4>
-                <p class="nb-related__meta">{{ a.published_at | date: "%b %e, %Y" }}</p>
-              </a>
-            </article>
-            {%- assign _shown = _shown | plus: 1 -%}
-          {%- endif -%}
-        {%- endif -%}
+   {%- comment -%} === Related posts (by shared tags; fallback to recent) === {%- endcomment -%}
+{%- assign _shown = 0 -%}
+{%- capture related_markup -%}
+  <div class="nb-related__grid">
+  {%- for a in blog.articles -%}
+    {%- if a.id != article.id and _shown < 3 -%}
+      {%- assign _overlap = false -%}
+      {%- for t in article.tags -%}
+        {%- if a.tags contains t -%}{%- assign _overlap = true -%}{%- endif -%}
       {%- endfor -%}
-      </div>
-    {%- endcapture -%}
+      {%- if _overlap -%}
+        {%- liquid
+          assign _wa = a.content | strip_html | split: ' ' | size
+          assign _ma = _wa | divided_by: 200
+          assign _ra = _wa | modulo: 200
+          if _ra > 0
+            assign _ma = _ma | plus: 1
+          endif
+          if _ma < 1
+            assign _ma = 1
+          endif
+        -%}
+        <article class="nb-related__card">
+          <a class="nb-related__link" href="{{ a.url }}">
+            {%- if a.image -%}
+              {{ a | image_url: width: 800 | image_tag: alt: a.title, class: 'nb-related__img', sizes: '(max-width: 740px) 100vw, 360px', widths: '360,540,720,800' }}
+            {%- endif -%}
+            <h4 class="nb-related__title">{{ a.title }}</h4>
+            <p class="nb-related__meta">{{ a.published_at | date: "%b %e, %Y" }} · {{ _ma }} min read</p>
+          </a>
+        </article>
+        {%- assign _shown = _shown | plus: 1 -%}
+      {%- endif -%}
+    {%- endif -%}
+  {%- endfor -%}
+  </div>
+{%- endcapture -%}
 
     <section class="nb-related">
-      <h3 class="nb-related__heading">Related reading</h3>
-      {%- if _shown > 0 -%}
-        {{ related_markup }}
-      {%- else -%}
-        <div class="nb-related__grid">
-        {%- assign _fallback_shown = 0 -%}
-        {%- for a in blog.articles -%}
-          {%- if a.id != article.id and _fallback_shown < 3 -%}
-            <article class="nb-related__card">
-              <a class="nb-related__link" href="{{ a.url }}">
-                {%- if a.image -%}
-                  {{ a | image_url: width: 800 | image_tag: alt: a.title, class: 'nb-related__img', sizes: '(max-width: 740px) 100vw, 360px', widths: '360,540,720,800' }}
-                {%- endif -%}
-                <h4 class="nb-related__title">{{ a.title }}</h4>
-                <p class="nb-related__meta">{{ a.published_at | date: "%b %e, %Y" }}</p>
-              </a>
-            </article>
-            {%- assign _fallback_shown = _fallback_shown | plus: 1 -%}
-          {%- endif -%}
-        {%- endfor -%}
-        </div>
+  <h3 class="nb-related__heading">Related reading</h3>
+  {%- if _shown > 0 -%}
+    {{ related_markup }}
+  {%- else -%}
+    <div class="nb-related__grid">
+    {%- assign _fallback_shown = 0 -%}
+    {%- for a in blog.articles -%}
+      {%- if a.id != article.id and _fallback_shown < 3 -%}
+        {%- liquid
+          assign _wa = a.content | strip_html | split: ' ' | size
+          assign _ma = _wa | divided_by: 200
+          assign _ra = _wa | modulo: 200
+          if _ra > 0
+            assign _ma = _ma | plus: 1
+          endif
+          if _ma < 1
+            assign _ma = 1
+          endif
+        -%}
+        <article class="nb-related__card">
+          <a class="nb-related__link" href="{{ a.url }}">
+            {%- if a.image -%}
+              {{ a | image_url: width: 800 | image_tag: alt: a.title, class: 'nb-related__img', sizes: '(max-width: 740px) 100vw, 360px', widths: '360,540,720,800' }}
+            {%- endif -%}
+            <h4 class="nb-related__title">{{ a.title }}</h4>
+            <p class="nb-related__meta">{{ a.published_at | date: "%b %e, %Y" }} · {{ _ma }} min read</p>
+          </a>
+        </article>
+        {%- assign _fallback_shown = _fallback_shown | plus: 1 -%}
       {%- endif -%}
-    </section>
+    {%- endfor -%}
+    </div>
+  {%- endif -%}
+</section>
 
     <nav class="nb-article-nav" aria-label="Article pagination">
       {% assign has_prev = article.previous %}

--- a/snippets/reading-time.liquid
+++ b/snippets/reading-time.liquid
@@ -1,0 +1,10 @@
+{%- comment -%}
+  Compute reading time at ~200 wpm.
+  Prefer full content; fallback to excerpt, then title (never empty).
+{%- endcomment -%}
+{%- assign _source = article.content | strip_html -%}
+{%- if _source == blank -%}{%- assign _source = article.excerpt | strip_html -%}{%- endif -%}
+{%- if _source == blank -%}{%- assign _source = article.title -%}{%- endif -%}
+{%- assign _words = _source | split: ' ' | size -%}
+{%- assign _read_mins = _words | plus: 199 | divided_by: 200 -%}
+{{ _read_mins }} min read


### PR DESCRIPTION
Blog listing cards (_blog-post-card) now show “· X min read” next to the date.
	•	Related cards on article page (main-blog-post) also append minutes.
	•	Uses the same calc across the site (ceil(words/200); minimum 1).
	•	No schema/JS changes; 3 lightweight CSS rules to keep the meta inline.