### PR TITLE
Update nibana-contact.liquid

### DIFF
--- a/sections/nibana-contact.liquid
+++ b/sections/nibana-contact.liquid
@@ -1,10 +1,12 @@
 {% comment %}
-  Nibana – Contact Section (v2)
+  Nibana – Contact Section (v2.1)
   - 2-panel layout: Info (left) + Form (right)
-  - Panels use color scheme + shadows, tuned via settings
-  - Global CTA classes configurable via settings
-  - Name, Purpose, Message are required
-  - Newsletter checkbox checked by default (toggle in settings)
+  - Uses global tokens from base.css:
+      • Call CTA: .nb-cta (optionally add .nb-cta--xl)
+      • Non-call CTA: .button
+      • Panels: .nib-panel
+  - Required: Name, Inquiry Purpose, Message
+  - Opt-in checkbox checked by default (Theme Editor toggle)
   - Hidden customer form creates/updates Customer with tags for Mailchimp sync
 {% endcomment %}
 
@@ -20,22 +22,20 @@
     }
     @media (min-width: 900px) {
       #{{ secid }} .nib-grid {
-        grid-template-columns: 1.05fr 1fr; /* left info slightly wider, like the inspiration */
+        grid-template-columns: 1.05fr 1fr;
         gap: 32px;
         align-items: start;
       }
     }
     #{{ secid }} .nib-card {
-      background: {{ section.settings.card_bg | default: 'var(--color-background, #ffffff)' }};
-      border: 1px solid {{ section.settings.card_border | default: 'rgba(0,0,0,.06)' }};
+      background: {{ section.settings.card_bg }};
+      border: 1px solid {{ section.settings.card_border }};
       border-radius: {{ section.settings.card_radius }};
       box-shadow: {{ section.settings.card_shadow }};
       padding: {{ section.settings.card_padding }};
     }
     #{{ secid }} .nib-muted { opacity: .8; }
-    #{{ secid }} .nib-label {
-      display:block; margin:0 0 6px 0; font-weight: 500;
-    }
+    #{{ secid }} .nib-label { display:block; margin:0 0 6px 0; font-weight: 500; }
     #{{ secid }} .nib-input, #{{ secid }} .nib-select, #{{ secid }} .nib-textarea {
       width:100%; padding:12px 14px; border:1px solid var(--color-input-border, #e5e7eb);
       border-radius: 10px; background:#fff;
@@ -47,7 +47,7 @@
 
   <div class="nib-grid">
     <!-- LEFT PANEL: Info + Details + Book a Call -->
-    <div class="nib-card">
+    <div class="nib-card nib-panel">
       <h1 class="{{ section.settings.heading_class }}" style="margin:0 0 6px 0;">
         {{ section.settings.heading }}
       </h1>
@@ -57,7 +57,7 @@
 
       <div style="display:grid; gap:18px;">
         <!-- Contact Details -->
-        <div class="nib-card" style="padding:16px;">
+        <div class="nib-card nib-panel" style="padding:16px;">
           <h3 class="{{ section.settings.block_heading_class }}" style="margin:0 0 8px 0;">{{ section.settings.details_heading }}</h3>
           <p style="margin:0;">
             <a href="mailto:{{ section.settings.details_email }}">{{ section.settings.details_email }}</a><br>
@@ -69,7 +69,7 @@
         </div>
 
         <!-- Prefer to talk -->
-        <div class="nib-card" style="padding:16px;">
+        <div class="nib-card nib-panel" style="padding:16px;">
           <h3 class="{{ section.settings.block_heading_class }}" style="margin:0 0 8px 0;">{{ section.settings.call_heading }}</h3>
           <p class="nib-muted" style="margin:0 0 12px 0;">{{ section.settings.call_sub }}</p>
           <a href="{{ section.settings.call_link }}"
@@ -82,15 +82,15 @@
     </div>
 
     <!-- RIGHT PANEL: Contact Form -->
-    <div class="nib-card">
+    <div class="nib-card nib-panel">
       {% form 'contact', id: 'NibanaContactForm', class: 'contact-form' %}
         {% if form.posted_successfully? %}
-          <div role="status" class="nib-card" style="padding:12px; background:#f6fff6; border-color:#d9ead3;">
+          <div role="status" class="nib-card nib-panel" style="padding:12px; background:#f6fff6; border-color:#d9ead3;">
             {{ section.settings.success_text }}
           </div>
         {% endif %}
         {% if form.errors %}
-          <div role="alert" class="nib-card" style="padding:12px; background:#fff5f5; border-color:#f3c2c2;">
+          <div role="alert" class="nib-card nib-panel" style="padding:12px; background:#fff5f5; border-color:#f3c2c2;">
             {{ section.settings.error_text }}
           </div>
         {% endif %}
@@ -215,7 +215,7 @@
     { "type": "text", "id": "call_heading", "label": "Prefer to talk — heading", "default": "Prefer to talk?" },
     { "type": "text", "id": "call_sub", "label": "Prefer to talk — subtext", "default": "Book a free 20-minute discovery call." },
     { "type": "text", "id": "call_label", "label": "Call CTA label", "default": "Book a Free 20-min Call" },
-    { "type": "url",  "id": "call_link", "label": "Call CTA link", "default": "/pages/book-a-call" },
+    { "type": "url",  "id": "call_link", "label": "Call CTA link" },
 
     { "type": "text", "id": "label_name", "label": "Form label — Name", "default": "Name" },
     { "type": "text", "id": "label_email", "label": "Form label — Email", "default": "Email" },
@@ -232,17 +232,17 @@
     { "type": "text", "id": "success_text", "label": "Success message", "default": "Thanks for reaching out — we’ll get back within 1 business day." },
     { "type": "text", "id": "error_text", "label": "Error message", "default": "Please check the highlighted fields and try again." },
 
-    { "type": "text", "id": "cta_submit_class", "label": "Submit button class (global non-call CTA)", "default": "nib-btn" },
-    { "type": "text", "id": "cta_call_class", "label": "Book-a-call button class (global call CTA)", "default": "nib-btn--call" },
-    { "type": "text", "id": "heading_class", "label": "Heading class", "default": "nib-heading-xl" },
-    { "type": "text", "id": "subheading_class", "label": "Subheading class", "default": "nib-text-lg" },
-    { "type": "text", "id": "block_heading_class", "label": "Panel heading class", "default": "nib-heading-md" },
+    { "type": "text", "id": "cta_submit_class", "label": "Submit button class (non-call CTA)", "default": "button" },
+    { "type": "text", "id": "cta_call_class", "label": "Book-a-call button class (call CTA)", "default": "nb-cta" },
+    { "type": "text", "id": "heading_class", "label": "Heading class", "default": "h1" },
+    { "type": "text", "id": "subheading_class", "label": "Subheading class", "default": "" },
+    { "type": "text", "id": "block_heading_class", "label": "Panel heading class", "default": "h3" },
 
     { "type": "text", "id": "max_width", "label": "Max width", "default": "1100px" },
     { "type": "text", "id": "section_padding", "label": "Section padding", "default": "48px 16px" },
 
     { "type": "color", "id": "card_bg", "label": "Panel background (fallback)", "default": "#ffffff" },
-    { "type": "color", "id": "card_border", "label": "Panel border (fallback)", "default": "rgba(0,0,0,.06)" },
+    { "type": "color", "id": "card_border", "label": "Panel border (fallback)", "default": "#E5E7EB" },
     { "type": "text",  "id": "card_radius", "label": "Panel border-radius", "default": "16px" },
     { "type": "text",  "id": "card_padding", "label": "Panel padding", "default": "22px" },
     { "type": "text",  "id": "card_shadow", "label": "Panel shadow", "default": "0 8px 24px rgba(0,0,0,.06)" }


### PR DESCRIPTION
	•	Map classes to global tokens (nb-cta, button, nib-panel).
	•	Remove invalid default from url setting call_link.
	•	Change card_border default to hex #E5E7EB.
	•	Keep required fields (Name, Purpose, Message) and default-checked opt-in.
	•	Editor controls for headings, copy, and classes remain.