### PR TITLE
Service pages: add mid-CTAs after Outcomes

### DIFF
--- a/sections/coaching-service.liquid
+++ b/sections/coaching-service.liquid
@@ -721,6 +721,10 @@
   /* slightly trim the trustbelt below the hero so rhythm matches */
   .nb-trustbelt{ padding-bottom: 6px; }
 </style>
+<style>
+  /* Mid-CTA utility */
+  .nb-midcta{ margin-top: clamp(10px,2vw,16px); text-align: center; }
+</style>
 
 {%- liquid
   assign oc_raw  = service.outcomes | append: ''
@@ -756,6 +760,11 @@
           {%- assign it = item | strip -%}
           {%- if it != '' -%}<div class="nb-outcome">{{ it }}</div>{%- endif -%}
         {%- endfor -%}
+      </div>
+      <div class="nb-midcta nb-midcta--outcomes">
+        <a class="nb-cta nb-cta--xl" href="{{ btn_href }}" data-cta="service-mid-cta-outcomes">
+          {{ btn_label }}
+        </a>
       </div>
     </div>
   </div>
@@ -1374,5 +1383,6 @@
 {%- else -%}
 <section class="page--width" style="padding:40px 0;"><p>No coaching service selected for this page.</p></section>
 {%- endif -%}
+
 
 


### PR DESCRIPTION
	•	Adds two inline CTAs on service pages at natural high-intent moments:
	•	Below Outcomes (data-cta="service-mid-cta-outcomes")
	•	Reuses existing btn_label / btn_href set at top of section.
	•	Adds .nb-midcta helper for consistent spacing/centering.
	•	No copy or design regressions; sticky + bottom CTA remain intact.