### PR TITLE
Service pages: add tag-filtered testimonials support

### DIFF
--- a/sections/testimonials.liquid
+++ b/sections/testimonials.liquid
@@ -21,6 +21,16 @@ Testimonials — grid/slider
     assign cta_label  = section.settings.cta_label      | default: 'View all'
     assign cta_link   = section.settings.cta_link       | default: '/pages/testimonial'
 
+    assign filter_raw  = section.settings.tag_filter | default: ''
+    assign filter_norm = filter_raw | downcase
+    assign filters     = filter_norm | split: ','
+    assign filter_on   = false
+    for f in filters
+      if f | strip != ''
+        assign filter_on = true
+      endif
+    endfor
+
     assign tag_bucket = ''
   -%}
 
@@ -41,13 +51,23 @@ Testimonials — grid/slider
       {%- assign mo_used = false -%}
       {%- assign count_so_far = 0 -%}
 
-      {%- if source == 'metaobject' -%}
-        {%- comment -%}
-          Iterate the metaobject_list setting directly.
-          We don't rely on `.size`; we just mark mo_used when we render at least one.
-        {%- endcomment -%}
+          {%- if source == 'metaobject' -%}
+        {%- comment -%} Filter by tags (if provided) and respect limit {%- endcomment -%}
         {%- for entry in section.settings.mo_list -%}
-          {%- if count_so_far < limit -%}
+          {%- liquid
+            assign include = true
+            if filter_on
+              assign include = false
+              assign et = entry.tags | join: ',' | downcase
+              for f in filters
+                assign f2 = f | strip
+                if f2 != '' and et contains f2
+                  assign include = true
+                endif
+              endfor
+            endif
+          -%}
+          {%- if include and count_so_far < limit -%}
             {%- assign mo_used = true -%}
             {%- assign count_so_far = count_so_far | plus: 1 -%}
 
@@ -69,16 +89,34 @@ Testimonials — grid/slider
         {%- endfor -%}
       {%- endif -%}
 
-      {%- unless mo_used -%}
-        {%- comment -%} Fall back to manual blocks {%- endcomment -%}
-        {%- for block in section.blocks limit: limit -%}
-          {%- assign q   = block.settings.quote    | default: '' -%}
-          {%- assign n   = block.settings.name     | default: '' -%}
-          {%- assign tt  = block.settings.title    | default: '' -%}
-          {%- assign loc = block.settings.location | default: '' -%}
-          {%- assign av  = block.settings.avatar -%}
-          {%- assign tg  = block.settings.tags     | default: '' -%}
-          {% render 'nb-testimonial-card', quote: q, name: n, title: tt, location: loc, avatar: av, tags: tg %}
+           {%- unless mo_used -%}
+        {%- comment -%} Fall back to manual blocks (with optional tag filter) {%- endcomment -%}
+        {%- for block in section.blocks -%}
+          {%- liquid
+            assign include = true
+            if filter_on
+              assign include = false
+              assign bt = block.settings.tags | downcase
+              for f in filters
+                assign f2 = f | strip
+                if f2 != '' and bt contains f2
+                  assign include = true
+                endif
+              endfor
+            endif
+          -%}
+          {%- if include -%}
+            {%- assign q   = block.settings.quote    | default: '' -%}
+            {%- assign n   = block.settings.name     | default: '' -%}
+            {%- assign tt  = block.settings.title    | default: '' -%}
+            {%- assign loc = block.settings.location | default: '' -%}
+            {%- assign av  = block.settings.avatar -%}
+            {%- assign tg  = block.settings.tags     | default: '' -%}
+            {% render 'nb-testimonial-card', quote: q, name: n, title: tt, location: loc, avatar: av, tags: tg %}
+
+            {%- assign count_so_far = count_so_far | plus: 1 -%}
+            {%- if count_so_far >= limit -%}{%- break -%}{%- endif -%}
+          {%- endif -%}
         {%- endfor -%}
       {%- endunless -%}
     {%- endcapture -%}
@@ -303,6 +341,8 @@ Testimonials — grid/slider
     { "type": "metaobject_list", "id": "mo_list", "label": "Testimonials (metaobject list)", "metaobject_type": "nb_testimonial" },
 
     { "type": "range", "id": "limit", "label": "Max items", "min": 1, "max": 60, "step": 1, "default": 12 },
+    { "type": "header", "content": "Filtering" },
+    { "type": "text", "id": "tag_filter", "label": "Filter by tags (comma separated)", "default": "" }
     { "type": "checkbox", "id": "show_filter", "label": "Show filter chips", "default": false },
 
     { "type": "header", "content": "Slider options" },
@@ -357,6 +397,7 @@ Testimonials — grid/slider
 ]
 }
 {% endschema %}
+
 
 
 


### PR DESCRIPTION
	•	Adds tag_filter setting and filter logic to testimonials.liquid for both metaobject and manual-block sources.
	•	Respects existing limit, grid/slider modes, and card renderer (nb-testimonial-card).
	•	Intended to place the section between Method and FAQ on service pages to surface contextually relevant social proof.