### PR TITLE
Global sticky CTA: auto-hide when call-booking CTAs are visible

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -500,5 +500,6 @@ It:
   });
 })();
 </script>
+{% render 'nb-sticky-cta-controller' %}
   </body>
 </html>

--- a/sections/coaching-service.liquid
+++ b/sections/coaching-service.liquid
@@ -178,10 +178,6 @@
   .nb-steps--curve li::after{ display:none; }
 }
 
-  /* Sticky mobile CTA */
-  .nb-sticky-cta{position:fixed;left:0;right:0;bottom:0;z-index:40;display:none;padding:max(10px, env(safe-area-inset-bottom));background:linear-gradient(to top, rgba(255,255,255,.98), rgba(255,255,255,.88));border-top:1px solid #e8ecef;backdrop-filter:saturate(180%) blur(6px)}
-  .nb-sticky-cta__btn{display:block;text-align:center;font-weight:700;text-decoration:none;background:var(--nb-chocolate);color:#fff;padding:.9rem 1.1rem;border-radius:999px;box-shadow:0 1px 3px rgba(0,0,0,.12)}
-  @media (max-width:860px){ .nb-sticky-cta{display:block} .nb-shell{padding-bottom:84px} }
 
   /* ===========================
      HERO SUPERKIT (full-bleed + effects)
@@ -1540,11 +1536,8 @@
   {%- endif -%}
 
   <!-- Bottom CTA centered (flex wrapper) -->
-  <div style="padding:10px 0 24px; display:flex; justify-content:center;">
-  <a class="nb-cta nb-cta--xl" href="{{ btn_href }}" data-cta="service-bottom-cta">{{ btn_label }}</a>
-  <div class="nb-sticky-cta" data-cta="service-sticky-cta">
-    <a class="button nb-sticky-cta__btn" href="{{ btn_href }}">{{ btn_label }}</a>
-  </div>
+<div style="padding:10px 0 24px; display:flex; justify-content:center;">
+  <a class="nb-cta nb-cta--xl" href="{{ btn_href }}" data-cta="book-call">{{ btn_label }}</a>
 </div>
 
 </section>
@@ -1552,6 +1545,7 @@
 {%- else -%}
 <section class="page--width" style="padding:40px 0;"><p>No coaching service selected for this page.</p></section>
 {%- endif -%}
+
 
 
 

--- a/snippets/nb-sticky-cta-controller.liquid
+++ b/snippets/nb-sticky-cta-controller.liquid
@@ -1,0 +1,112 @@
+{%- comment -%}
+Global controller for the mobile sticky CTA.
+Hides the sticky bar when a *call-booking* CTA is visible.
+- Sticky bar selector: .nb-sticky-cta  (this is your existing global bar)
+- Auto-detect booking CTAs: anchors/buttons that link to booking URLs (no per-page tagging required)
+- Optional opt-in: any element with [data-cta="book-call"] will also be observed
+{%- endcomment -%}
+
+<style>
+  .nb-sticky-cta{ transition: transform .28s ease, opacity .2s ease; will-change: transform; }
+  .nb-sticky-cta.is-hidden{ transform: translateY(140%); opacity: 0; pointer-events: none; }
+  .nb-sticky-cta{ bottom: max(12px, env(safe-area-inset-bottom)); }
+</style>
+
+<script>
+(function(){
+  var sticky = document.querySelector('.nb-sticky-cta');
+  if(!sticky) return;
+
+  // Only care on mobile-ish widths (matches where your bar is visible)
+  var mm = window.matchMedia('(max-width: 960px)');
+  if(!mm.matches) return;
+
+  var HIDDEN = 'is-hidden';
+  function setHidden(v){ sticky.classList.toggle(HIDDEN, !!v); }
+
+  // Booking URL patterns (edit if your booking URL changes)
+  var BOOKING_URL_PATTERNS = [
+    /\/pages\/book-a-call/i,
+    /book-a-call/i,
+    /\/book\b/i,
+    /\/schedule\b/i,
+    /calendly\.com/i,
+    /cal\.com/i,
+    /tidycal\.com/i,
+    /youcanbook\.me/i
+  ];
+
+  function isBookingLink(el){
+    if(!el) return false;
+    // explicit opt-in
+    if(el.dataset && el.dataset.cta === 'book-call') return true;
+
+    var href = el.getAttribute && el.getAttribute('href');
+    // Also consider absolute URL in .href
+    var full = el.href || '';
+    if(href){
+      for(var i=0;i<BOOKING_URL_PATTERNS.length;i++){
+        if(BOOKING_URL_PATTERNS[i].test(href)) return true;
+      }
+    }
+    if(full){
+      for(var j=0;j<BOOKING_URL_PATTERNS.length;j++){
+        if(BOOKING_URL_PATTERNS[j].test(full)) return true;
+      }
+    }
+    return false;
+  }
+
+  function collectTargets(){
+    var arr = [];
+    // Explicit opt-ins
+    arr = arr.concat([].slice.call(document.querySelectorAll('[data-cta="book-call"]')));
+    // All anchors that look like booking links
+    var anchors = [].slice.call(document.querySelectorAll('a[href]'));
+    anchors.forEach(function(a){
+      if (sticky.contains(a)) return; // ignore anything inside the sticky itself
+      if (isBookingLink(a)) arr.push(a);
+    });
+    // Optional: buttons that trigger booking (if you ever use them)
+    var btns = [].slice.call(document.querySelectorAll('button'));
+    btns.forEach(function(b){
+      if (sticky.contains(b)) return;
+      if (b.dataset && b.dataset.cta === 'book-call') arr.push(b);
+    });
+    // De-dupe
+    return Array.from(new Set(arr));
+  }
+
+  var targets = collectTargets();
+
+  if(!('IntersectionObserver' in window) || !targets.length){
+    setHidden(false);
+    return;
+  }
+
+  var anyVisible = false;
+  var io = new IntersectionObserver(function(entries){
+    anyVisible = entries.some(function(e){ return e.isIntersecting && e.intersectionRatio > 0.2; });
+    setHidden(anyVisible);
+  }, { root: null, threshold: [0, 0.2, 0.4, 1], rootMargin: '0px 0px -8% 0px' });
+
+  targets.forEach(function(el){ io.observe(el); });
+
+  // Re-scan if the DOM changes (sections load, SPA-ish nav, etc.)
+  var mo = new MutationObserver(function(){
+    var fresh = collectTargets();
+    fresh.forEach(function(el){ io.observe(el); });
+  });
+  mo.observe(document.documentElement, {childList:true, subtree:true});
+
+  // Optional analytics
+  var clickEl = sticky.querySelector('a,button');
+  if(clickEl){
+    clickEl.addEventListener('click', function(){
+      try{ (window.dataLayer = window.dataLayer || []).push({event:'cta_sticky_click', href: clickEl.getAttribute('href')}); }catch(_){}
+    }, { passive:true });
+  }
+
+  window.addEventListener('pagehide', function(){ try{ io.disconnect(); mo.disconnect(); }catch(_){} });
+})();
+</script>


### PR DESCRIPTION
Adds a global controller snippet that observes booking CTAs (by URL patterns or [data-cta="book-call"]) and hides the floating bar when they’re in view; no per-page changes required.