### PR TITLE
About page — template wire-up + testimonials section wrapper

### DIFF
--- a/sections/about-testimonials.liquid
+++ b/sections/about-testimonials.liquid
@@ -1,0 +1,40 @@
+{% comment %}
+About — Testimonials
+Thin wrapper around the shared 'nb-service-testimonials-belt' snippet
+so it can be added as a proper Section in the Theme Editor.
+
+Defaults:
+- heading: What our clients say
+- tag_filter: All (no filtering)
+- limit: 6
+- carousel: true
+{% endcomment %}
+
+{% liquid
+  assign _heading  = section.settings.heading  | default: 'What our clients say'
+  assign _limit    = section.settings.limit    | default: 6
+  assign _carousel = section.settings.carousel | default: true
+  assign _tag      = section.settings.tag_filter | default: 'All'
+%}
+
+{%- render 'nb-service-testimonials-belt',
+  heading: _heading,
+  tag_filter: _tag,
+  limit: _limit,
+  carousel: _carousel
+-%}
+
+{% schema %}
+{
+  "name": "About — Testimonials",
+  "settings": [
+    { "type": "text", "id": "heading", "label": "Heading", "default": "What our clients say" },
+    { "type": "range", "id": "limit", "label": "Max items", "min": 1, "max": 12, "step": 1, "default": 6 },
+    { "type": "checkbox", "id": "carousel", "label": "Enable slider", "default": true },
+    { "type": "text", "id": "tag_filter", "label": "Tag filter (comma-separated or 'All')", "default": "All" }
+  ],
+  "presets": [
+    { "name": "About — Testimonials", "category": "Testimonials" }
+  ]
+}
+{% endschema %}

--- a/templates/page.about.json
+++ b/templates/page.about.json
@@ -1,0 +1,33 @@
+{
+  "sections": {
+    "trustbelt": {
+      "type": "nb-trustbelt",
+      "settings": {
+        "heading": "",
+        "layout": "belt",
+        "speed": 22,
+        "items_text": "Trusted by founders\nLoved by couples\nUsed by executives",
+        "pad_top": 0,
+        "pad_bottom": 0
+      }
+    },
+    "about_testimonials": {
+      "type": "about-testimonials",
+      "settings": {
+        "heading": "What our clients say",
+        "limit": 6,
+        "carousel": true,
+        "tag_filter": "All"
+      }
+    },
+    "faq": {
+      "type": "nb-faq",
+      "settings": { }
+    }
+  },
+  "order": [
+    "trustbelt",
+    "about_testimonials",
+    "faq"
+  ]
+}


### PR DESCRIPTION
	•	Adds sections/about-testimonials.liquid (forwarder to nb-service-testimonials-belt, defaults to tag_filter: All, limit 6, slider enabled).
	•	Adds templates/page.about.json with initial sections: nb-trustbelt, about-testimonials, and nb-faq.
	•	Preps the About page for PR A2 sections (Who we help, Pillars, Compare, Founder, Origins).