### PR TITLE
Add challenge mini-blocks with loop diagram

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -5334,6 +5334,22 @@ body.nb-typography{
 .nb-blog-hero__title{margin:0 0 6px}
 .nb-blog-hero__dek{color:var(--nb-muted,#324247);margin:0 0 12px}
 
+.nb-ch{padding:clamp(48px,6vw,96px) 0;color:var(--nb-ink)}
+.nb-ch__wrap{max-width:min(1120px,94vw);margin-inline:auto}
+.nb-ch__grid{display:grid;gap:clamp(20px,2.5vw,40px);grid-template-columns:1.2fr .8fr;align-items:start}
+.nb-ch__list{display:flex;flex-direction:column}
+.nb-ch__item{padding:0 0 clamp(16px,2vw,24px);border-bottom:1px solid color-mix(in oklab,var(--nb-ink),transparent 90%)}
+.nb-ch__item:last-child{border-bottom:0}
+.nb-ch__hd{font-weight:600;margin:0 0 6px;line-height:1.3;overflow-wrap:anywhere}
+.nb-ch__bd{color:var(--nb-muted);line-height:1.6;overflow-wrap:anywhere}
+.nb-ch__viz{display:flex;align-items:center;justify-content:center}
+.nb-ch__viz > *{width:100%;max-width:360px}
+.nb-loop-diagram{display:block;width:100%;max-height:520px;height:auto;color:var(--nb-ink)}
+@media (max-width:860px){
+  .nb-ch__grid{grid-template-columns:1fr}
+  .nb-ch__viz{order:-1}
+}
+
 /* Tag chips (optional) */
 .nb-tagbar{ margin: 6px 0 16px; }
 .nb-tagbar__list{ display:flex; flex-wrap:wrap; gap:10px; margin:0; padding:0; list-style:none; }

--- a/sections/coaching-service.liquid
+++ b/sections/coaching-service.liquid
@@ -1270,6 +1270,65 @@
   {%- endif -%}
 {%- endfor -%}
 
+{%- liquid
+  assign challenge_raw = service.challenge_points | append: ''
+  assign challenge_clean = challenge_raw | replace: '\r', ''
+  assign challenge_lines = challenge_clean | split: '\n'
+  assign challenge_count = 0
+-%}
+{%- capture challenge_items -%}
+  {%- for line in challenge_lines -%}
+    {%- assign entry = line | strip -%}
+    {%- if entry != '' -%}
+      {%- assign heading = entry -%}
+      {%- assign body = '' -%}
+
+      {%- if entry contains ' — ' -%}
+        {%- assign heading = entry | split: ' — ' | first | strip -%}
+        {%- assign body = entry | remove_first: heading -%}
+        {%- assign body = body | remove_first: ' — ' | strip -%}
+      {%- elsif entry contains '—' -%}
+        {%- assign heading = entry | split: '—' | first | strip -%}
+        {%- assign body = entry | remove_first: heading -%}
+        {%- assign body = body | remove_first: '—' | strip -%}
+      {%- elsif entry contains ' - ' -%}
+        {%- assign heading = entry | split: ' - ' | first | strip -%}
+        {%- assign body = entry | remove_first: heading -%}
+        {%- assign body = body | remove_first: ' - ' | strip -%}
+      {%- elsif entry contains '-' -%}
+        {%- assign heading = entry | split: '-' | first | strip -%}
+        {%- assign body = entry | remove_first: heading -%}
+        {%- assign body = body | remove_first: '-' | strip -%}
+      {%- endif -%}
+
+      {%- if heading != '' -%}
+        {%- assign challenge_count = challenge_count | plus: 1 -%}
+        <div class="nb-ch__item">
+          <div class="nb-ch__hd">{{ heading | escape }}</div>
+          {%- if body != '' -%}
+            <div class="nb-ch__bd">{{ body | escape }}</div>
+          {%- endif -%}
+        </div>
+      {%- endif -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endcapture -%}
+
+{%- if challenge_count > 0 -%}
+  <section class="nb-ch">
+    <div class="nb-ch__wrap">
+      <div class="nb-ch__grid">
+        <div class="nb-ch__list">
+          {{ challenge_items }}
+        </div>
+        <div class="nb-ch__viz">
+          {% render 'nb-loop-diagram' %}
+        </div>
+      </div>
+    </div>
+  </section>
+{%- endif -%}
+
 {%- endif -%}
 
  {%- comment -%} MYTHS / TRUTHS — Before → After compare rows {%- endcomment -%}

--- a/snippets/nb-loop-diagram.liquid
+++ b/snippets/nb-loop-diagram.liquid
@@ -1,0 +1,18 @@
+<svg class="nb-loop-diagram" viewBox="0 0 220 520" aria-hidden="true" focusable="false">
+  <g fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="110" cy="60" r="28" />
+    <circle cx="110" cy="190" r="28" />
+    <circle cx="110" cy="320" r="28" />
+    <circle cx="110" cy="450" r="28" />
+    <path d="M110 95 C 170 125 170 155 110 185" />
+    <path d="M110 225 C 170 255 170 285 110 315" />
+    <path d="M110 355 C 170 385 170 415 110 445" />
+    <path d="M92 474 C 32 420 32 130 92 76" />
+  </g>
+  <g fill="currentColor">
+    <path d="M110 186 L116 174 L104 174 Z" />
+    <path d="M110 316 L116 304 L104 304 Z" />
+    <path d="M110 446 L116 434 L104 434 Z" />
+    <path d="M100 86 L90 90 L99 98 Z" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- parse `challenge_points` into structured mini-blocks with headings and body copy
- style the new challenge section and ensure responsive stacking with the loop diagram
- add an inline SVG loop diagram snippet for the visual column

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cec5f5d7d08331b80c682b9fab52e4