### PR TITLE
Service Explainer + Challenges (two-column) + optional loop SVG

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -5359,3 +5359,55 @@ body.nb-typography{
   padding-top: 12px;
 }
 
+/* ========== Explainer + Challenges ========== */
+.nb-explainer{
+  padding: clamp(48px,6vw,96px) 0;
+  border-radius: 18px;
+  background: var(--nb-pebble);
+}
+.nb-explainer__wrap{
+  max-width: var(--nb-shell, 1180px);
+  margin: 0 auto;
+  padding: 0 clamp(16px,2vw,28px);
+}
+.nb-explainer__hd{
+  margin: 0 0 clamp(14px,2vw,18px);
+  font-weight: 700;
+}
+.nb-explainer__grid{
+  display: grid;
+  gap: clamp(18px,2.2vw,28px);
+}
+.nb-explainer--two{ grid-template-columns: 1.25fr 0.75fr; }
+.nb-explainer--one{ grid-template-columns: 1fr; }
+@media (max-width: 860px){
+  .nb-explainer--two{ grid-template-columns: 1fr; }
+}
+.nb-explainer__body p{ margin: 0 0 12px; }
+.nb-explainer__subhd{
+  font-size: clamp(16px,1.5vw,18px);
+  margin: 2px 0 10px;
+  font-weight: 700;
+}
+.nb-explainer__list{
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.nb-explainer__item{
+  display: flex;
+  align-items: flex-start;
+}
+.nb-explainer__icon{
+  width: 18px; height: 18px; flex: 0 0 18px;
+  border-radius: 6px;
+  background: color-mix(in oklab, var(--nb-ink), transparent 70%);
+  margin-right: 10px; margin-top: 3px;
+}
+.nb-explainer__col--right .nb-loop{
+  margin-top: clamp(12px,2vw,18px);
+  opacity: .9;
+}
+

--- a/sections/coaching-service.liquid
+++ b/sections/coaching-service.liquid
@@ -691,162 +691,58 @@
   .nb-midcta{ margin-top: clamp(10px,2vw,16px); text-align: center; }
 </style>
 
-{%- comment -%} EXPLAINER — “What is {{ service.title }} at Nibana?” (placed under trustbelt) {%- endcomment -%}
-{%- liquid
-  assign ex_title = service.explainer_title
-  assign ex_rich  = service.explainer_richtext
+{%- comment -%}
+  Explainer + Challenges panel
+  Uses existing Coaching Service metaobject fields:
+  - service.explainer_title
+  - service.explainer_richtext
+  - service.explainer_points  (multiline: one challenge per line)
+{%- endcomment -%}
 
-  assign ex_bullets_raw = service.explainer_points | append: ''
-  assign ex_html  = ex_bullets_raw | newline_to_br
-  assign br_tag   = '<br />'
-  assign ex_norm  = ex_html | replace: '<br/>', br_tag | replace: '<br>', br_tag | replace: '&nbsp;', ' '
-  assign ex_pipe  = ex_norm | replace: br_tag, '|||'
-  assign ex_items = ex_pipe | split: '|||'
+{%- assign ex_title = service.explainer_title -%}
+{%- assign ex_rich  = service.explainer_richtext -%}
 
-  assign ex_count = 0
-  for it in ex_items
-    assign t = it | strip
-    if t != ''
-      assign ex_count = ex_count | plus: 1
-    endif
-  endfor
+{%- assign ex_points_raw = service.explainer_points | newline_to_br -%}
+{%- assign ex_points = ex_points_raw | split: '<br />' | compact -%}
+{%- assign has_points = ex_points.size > 0 and ex_points[0] != '' -%}
 
-  assign _svc_title = service.title | default: 'Transformational Life Coaching'
-  if ex_title != blank
-    assign ex_heading = ex_title
-  else
-    assign ex_heading = 'What is ' | append: _svc_title | append: ' at Nibana?'
-  endif
--%}
+<section class="nb-explainer tone-pebble" id="nb-explainer-{{ section.id }}">
+  <div class="nb-explainer__wrap">
+    {%- if ex_title != blank -%}
+      <h2 class="nb-explainer__hd">{{ ex_title }}</h2>
+    {%- endif -%}
 
-{%- if ex_title or ex_rich or ex_count > 0 -%}
-<style>
-  /* ===== Explainer — Editorial Luxe A* ===== */
-  .nb-explainer{
-    background:#fff;
-    border:1px solid #eef2f5;              /* hairline border */
-    border-radius:24px;
-    padding: clamp(22px, 3vw, 36px);
-    box-shadow: 0 30px 80px rgba(0,0,0,.045); /* softer, wider */
-  }
+    <div class="nb-explainer__grid {% if has_points %}nb-explainer--two{% else %}nb-explainer--one{% endif %}">
+      <div class="nb-explainer__col nb-explainer__col--left">
+        {%- if ex_rich != blank -%}
+          <div class="nb-explainer__body rte">
+            {{ ex_rich }}
+          </div>
+        {%- endif -%}
+      </div>
 
-  /* Center the inner content and cap width */
- .nb-explainer__wrap{ max-width: none; margin: 0; }
+      {%- if has_points -%}
+      <aside class="nb-explainer__col nb-explainer__col--right" aria-label="Common challenges this addresses">
+        <h3 class="nb-explainer__subhd">{{ section.settings.explainer_points_heading }}</h3>
+        <ul class="nb-explainer__list" role="list">
+          {%- for p in ex_points -%}
+            {%- if p != blank -%}
+              <li class="nb-explainer__item">
+                <span class="nb-explainer__icon" aria-hidden="true"></span>
+                {{ p | strip }}
+              </li>
+            {%- endif -%}
+          {%- endfor -%}
+        </ul>
 
-  /* Heading: a touch lighter for refinement */
-  .nb-explainer__title{
-    margin:0 0 clamp(14px,2.4vw,20px);
-    letter-spacing:-0.01em;
-    font-weight: 600;                       /* down a notch */
-  }
-
-  /* Lede + body copy width cap for editorial feel */
-  .nb-explainer__rte{ max-width: none; }
-  .nb-explainer__rte p:first-child{
-    font-size:clamp(1.02rem,1.1vw,1.15rem);
-    color: rgb(var(--color-foreground-rgb) / 0.80);
-    margin-top: 2px;
-  }
-  .nb-explainer__rte p{
-    color: rgb(var(--color-foreground-rgb) / 0.92);
-    line-height:1.7;
-  }
-
-  /* Bullets → elegant rows (fixed, comfy columns) */
-.nb-explainer__list{
-  list-style:none; margin: clamp(12px,2vw,16px) 0 0; padding:0;
-  display:grid; row-gap: 10px; column-gap: 28px;
-  grid-template-columns: repeat(2, minmax(0,1fr));  /* full-width columns */
-}
-@media (max-width: 900px){
-  .nb-explainer__list{ grid-template-columns:1fr; }
-}
-
- .nb-explainer__li{
-  position:relative;
-  background: transparent;
-  padding: .9rem 0 1rem 2.1rem;   /* room for the dot */
-  line-height: 1.6;
-  transition: transform .28s ease, opacity .28s ease;
-  will-change: transform, opacity;
-}
-
-  /* Gutter rule that starts after the dot (cleaner than full-width border) */
-  .nb-explainer__li::after{
-    content:""; position:absolute; left:2.1rem; right:0; top:0;
-    height:1px; background:#f1f4f6;
-  }
-  /* hide the top rule for the first row in each column */
-  .nb-explainer__li:nth-child(-n+2)::after{ display:none; }
-  @media (max-width: 900px){ .nb-explainer__li:first-child::after{ display:none; } }
-
-  /* Brand dot with halo, aligned to the first line */
-  .nb-explainer__li::before{
-    content:""; position:absolute; left:.6rem; top: .88em;   /* refined align */
-    width:8px; height:8px; border-radius:50%;
-    background: var(--nb-chocolate);
-    box-shadow:0 0 0 6px color-mix(in oklab, var(--nb-chocolate), #fff 88%);
-  }
-
-  /* Micro-interaction: hover/focus lift */
-  .nb-explainer__li:hover,
-  .nb-explainer__li:focus-within{ transform: translateY(-2px); }
-
-  /* On-scroll reveal (honors reduced motion) */
-  @media (prefers-reduced-motion: no-preference){
-    .nb-ex-anim{ opacity:0; transform: translateY(6px); }
-    .nb-ex-anim.in{ opacity:1; transform:none; transition: transform .45s ease, opacity .45s ease; }
-  }
-</style>
-
-<section class="nb-explainer">
-  <div class="nb-shell">
-    <div class="nb-explainer__wrap nb-panel--mint" style="position:relative; padding: clamp(18px, 2.2vw, 26px);" data-anim>
-      <img class="nb-motif nb-motif--tr" src="{{ 'swash-01.svg' | asset_url }}" alt="">
-
-      <h2 class="nb-h2 nb-explainer__title">{{ ex_heading }}</h2>
-
-      {%- if ex_rich -%}
-        <div class="nb-rte nb-explainer__rte">
-          {{ ex_rich | metafield_tag }}
-        </div>
+        {%- if section.settings.show_loop_diagram and ex_points.size >= 4 -%}
+          {%- render 'nb-loop-diagram' -%}
+        {%- endif -%}
+      </aside>
       {%- endif -%}
-
-      {%- if ex_count > 0 -%}
-  <ul class="nb-explainer__list">
-    {%- for it in ex_items -%}
-      {%- assign t = it | strip -%}
-      {%- if t != '' -%}
-        <li class="nb-explainer__li nb-ex-anim">{{ t }}</li>
-      {%- endif -%}
-    {%- endfor -%}
-  </ul>
-{%- endif -%}
     </div>
   </div>
 </section>
-<script>
-  (function(){
-    var root = document.querySelector('.nb-explainer');
-    if(!root) return;
-    var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    if(reduce) return;
-    var items = root.querySelectorAll('.nb-ex-anim');
-    if(!items.length) return;
-
-    var io = new IntersectionObserver(function(entries){
-      entries.forEach(function(e){
-        if(e.isIntersecting){
-          e.target.classList.add('in');
-          io.unobserve(e.target);
-        }
-      });
-    }, { rootMargin: '0px 0px -10% 0px', threshold: 0.1 });
-
-    items.forEach(function(el){ io.observe(el); });
-  })();
-</script>
-{%- endif -%}
 
 {%- liquid
   assign oc_raw  = service.outcomes | append: ''
@@ -1550,6 +1446,32 @@
 {%- else -%}
 <section class="page--width" style="padding:40px 0;"><p>No coaching service selected for this page.</p></section>
 {%- endif -%}
+
+{% schema %}
+{
+  "name": "Coaching service",
+  "settings": [
+    {
+      "type": "text",
+      "id": "explainer_points_heading",
+      "label": "Challenges heading",
+      "default": "Common challenges this addresses"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_loop_diagram",
+      "label": "Show loop diagram",
+      "default": false
+    }
+  ],
+  "blocks": [],
+  "presets": [
+    {
+      "name": "Coaching service"
+    }
+  ]
+}
+{% endschema %}
 
 
 

--- a/snippets/nb-loop-diagram.liquid
+++ b/snippets/nb-loop-diagram.liquid
@@ -1,0 +1,35 @@
+{%- comment -%} Slim loop diagram: Pressure → Perform → Numb → Repeat {%- endcomment -%}
+<svg class="nb-loop" viewBox="0 0 360 520" role="img" aria-label="Loop: Pressure, Perform, Numb, Repeat">
+  <defs>
+    <style>
+      .nbl-s { stroke: currentColor; stroke-width: 1; fill: none; }
+      .nbl-t { fill: currentColor; font: 12px/1.2 system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; opacity:.85; }
+    </style>
+  </defs>
+
+  <!-- Nodes -->
+  <circle class="nbl-s" cx="180" cy="60"  r="26"></circle>
+  <text class="nbl-t" x="180" y="60" text-anchor="middle" dominant-baseline="middle">Pressure</text>
+
+  <circle class="nbl-s" cx="300" cy="200" r="26"></circle>
+  <text class="nbl-t" x="300" y="200" text-anchor="middle" dominant-baseline="middle">Perform</text>
+
+  <circle class="nbl-s" cx="180" cy="340" r="26"></circle>
+  <text class="nbl-t" x="180" y="340" text-anchor="middle" dominant-baseline="middle">Numb</text>
+
+  <circle class="nbl-s" cx="60"  cy="200" r="26"></circle>
+  <text class="nbl-t" x="60"  y="200" text-anchor="middle" dominant-baseline="middle">Repeat</text>
+
+  <!-- Arrows -->
+  <path class="nbl-s" d="M200 78 C245 110, 270 140, 290 174"></path>
+  <polygon fill="currentColor" points="296,180 286,176 291,171"></polygon>
+
+  <path class="nbl-s" d="M282 220 C250 262, 220 300, 196 320"></path>
+  <polygon fill="currentColor" points="188,326 193,316 198,321"></polygon>
+
+  <path class="nbl-s" d="M160 322 C120 290, 95 260, 70 226"></path>
+  <polygon fill="currentColor" points="64,218 74,222 69,227"></polygon>
+
+  <path class="nbl-s" d="M78 182 C108 140, 140 110, 164 90"></path>
+  <polygon fill="currentColor" points="172,84 167,94 162,89"></polygon>
+</svg>


### PR DESCRIPTION
## Summary
- replace the service explainer block with a two-column layout that pulls explainer text and challenge bullets from the metaobject, including optional loop diagram rendering
- add global styles for the new explainer layout and challenges list treatment
- create the reusable nb-loop-diagram snippet and expose section settings for the challenges heading and optional loop graphic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cecdf4357c83318bc045c553e170af