### PR TITLE
Render explainer rich text as HTML

### DIFF
--- a/sections/coaching-service.liquid
+++ b/sections/coaching-service.liquid
@@ -722,7 +722,7 @@
       <div class="nb-explainer__col nb-explainer__col--left">
         {%- if ex_rich != blank -%}
           <div class="nb-explainer__body rte">
-            {{ ex_rich }}
+            {{ ex_rich | metafield_tag }}
           </div>
         {%- endif -%}
       </div>


### PR DESCRIPTION
## Summary
- render the explainer body rich text using the metafield_tag filter so stored HTML outputs correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ced7a9132883319c4f3049741c1eaa