### PR TITLE
Make explainer panel tone opt-in

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -5363,8 +5363,11 @@ body.nb-typography{
 .nb-explainer{
   padding: clamp(48px,6vw,96px) 0;
   border-radius: 18px;
-  background: var(--nb-pebble);
+  background: var(--tone-bg, transparent);
 }
+.nb-explainer.tone-white{ --tone-bg: var(--nb-white, #ffffff); }
+.nb-explainer.tone-pebble{ --tone-bg: var(--nb-pebble, #f5f6f4); }
+.nb-explainer.tone-sage{ --tone-bg: var(--nb-sage, #eaf4f3); }
 .nb-explainer__wrap{
   max-width: var(--nb-shell, 1180px);
   margin: 0 auto;

--- a/sections/coaching-service.liquid
+++ b/sections/coaching-service.liquid
@@ -712,7 +712,7 @@
   {%- endif -%}
 {%- endif -%}
 
-<section class="nb-explainer tone-pebble" id="nb-explainer-{{ section.id }}">
+<section class="nb-explainer" id="nb-explainer-{{ section.id }}">
   <div class="nb-explainer__wrap">
     {%- if ex_title != blank -%}
       <h2 class="nb-explainer__hd">{{ ex_title }}</h2>


### PR DESCRIPTION
## Summary
- default the explainer panel background to a transparent surface
- add tone helper utilities for nb-explainer panels to opt into tinted surfaces
- remove the hard-coded pebble tone from the coaching service explainer section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ced821113483319ea98964b64a2eaf