### PR TITLE
Add inset panel styling for coaching explainer

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -5361,9 +5361,9 @@ body.nb-typography{
 
 /* ========== Explainer + Challenges ========== */
 .nb-explainer{
-  padding: clamp(48px,6vw,96px) 0;
+  padding: clamp(48px,6vw,96px) clamp(18px,6vw,96px);
   border-radius: 18px;
-  background: var(--tone-bg, transparent);
+  background: var(--tone-bg, var(--nb-sage, #eaf4f3));
 }
 .nb-explainer.tone-white{ --tone-bg: var(--nb-white, #ffffff); }
 .nb-explainer.tone-pebble{ --tone-bg: var(--nb-pebble, #f5f6f4); }
@@ -5376,6 +5376,12 @@ body.nb-typography{
 .nb-explainer__hd{
   margin: 0 0 clamp(14px,2vw,18px);
   font-weight: 700;
+}
+.nb-explainer__panel{
+  background: var(--nb-white, #ffffff);
+  border-radius: var(--nb-radius-lg);
+  box-shadow: var(--nb-shadow-1);
+  padding: clamp(24px,3vw,40px);
 }
 .nb-explainer__grid{
   display: grid;

--- a/sections/coaching-service.liquid
+++ b/sections/coaching-service.liquid
@@ -718,7 +718,8 @@
       <h2 class="nb-explainer__hd">{{ ex_title }}</h2>
     {%- endif -%}
 
-    <div class="nb-explainer__grid {% if has_points %}nb-explainer--two{% else %}nb-explainer--one{% endif %}">
+    <div class="nb-explainer__panel">
+      <div class="nb-explainer__grid {% if has_points %}nb-explainer--two{% else %}nb-explainer--one{% endif %}">
       <div class="nb-explainer__col nb-explainer__col--left">
         {%- if ex_rich != blank -%}
           <div class="nb-explainer__body rte">
@@ -746,6 +747,7 @@
         {%- endif -%}
       </aside>
       {%- endif -%}
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- update the explainer section background to use the sage tone and add extra padding for the inset layout
- introduce an nb-explainer__panel card treatment with white surface, rounded corners, and shadow
- wrap the coaching service explainer grid in the new panel container to apply the updated card styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cedae4ccc4833189753dbd510432b3