### PR TITLE
Explainer + Challenges — luxury polish (card, bullets, spacing, mobile tidy)

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -5359,3 +5359,102 @@ body.nb-typography{
   padding-top: 12px;
 }
 
+/* ========== Explainer + Challenges (V2 polish) ========== */
+.nb-explainer{
+  /* bigger outer air, consistent with service hero rhythm */
+  padding: clamp(56px,7vw,112px) clamp(18px,6vw,96px);
+  border-radius: 22px;
+  background: var(--tone-bg, var(--nb-sage, #eaf4f3));
+  position: relative;
+}
+
+/* optional tones (explicit) */
+.nb-explainer.tone-white{ --tone-bg: var(--nb-white, #ffffff); }
+.nb-explainer.tone-pebble{ --tone-bg: var(--nb-pebble, #f5f6f4); }
+.nb-explainer.tone-sage{ --tone-bg: var(--nb-sage, #eaf4f3); }
+
+/* shell + heading */
+.nb-explainer__wrap{
+  max-width: var(--nb-shell, 1180px);
+  margin: 0 auto;
+  padding: 0 clamp(16px,2vw,28px);
+}
+.nb-explainer__hd{
+  margin: 0 0 clamp(16px,2.4vw,22px);
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  color: var(--nb-ink, #2f3e48);
+}
+
+/* inner card panel */
+.nb-explainer__panel{
+  background: var(--nb-white, #ffffff);
+  border: 1px solid color-mix(in oklab, var(--nb-ink, #2f3e48), #fff 90%);
+  border-radius: var(--nb-radius-lg, 20px);
+  box-shadow: var(--nb-shadow-1, 0 10px 28px rgba(0,0,0,.06));
+  padding: clamp(22px,2.8vw,34px);
+}
+
+/* grid */
+.nb-explainer__grid{
+  display: grid;
+  gap: clamp(18px,2.2vw,28px);
+}
+.nb-explainer--two{ grid-template-columns: 1.25fr 0.75fr; }
+.nb-explainer--one{ grid-template-columns: 1fr; }
+@media (max-width: 1024px){
+  .nb-explainer--two{ grid-template-columns: 1fr; }
+}
+
+/* copy */
+.nb-explainer__body p{ margin: 0 0 12px; }
+.nb-explainer__body p:last-child{ margin-bottom: 0; }
+
+/* right column header */
+.nb-explainer__subhd{
+  font-size: clamp(15px,1.5vw,18px);
+  margin: 2px 0 10px;
+  font-weight: 700;
+  color: var(--nb-ink, #2f3e48);
+}
+
+/* list */
+.nb-explainer__list{
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* bullet → refined “tick-dot” with better alignment */
+.nb-explainer__item{
+  display: grid;
+  grid-template-columns: 18px 1fr;
+  align-items: start;
+  gap: 10px;
+}
+.nb-explainer__icon{
+  width: 18px; height: 18px;
+  border-radius: 6px;
+  background: color-mix(in oklab, var(--nb-ink, #2f3e48), transparent 75%);
+  position: relative;
+  margin-top: 2px;
+}
+.nb-explainer__icon::after{
+  content: "";
+  position: absolute; inset: 0;
+  -webkit-mask: radial-gradient(circle at 50% 50%, #000 52%, transparent 53%);
+          mask: radial-gradient(circle at 50% 50%, #000 52%, transparent 53%);
+  background: #fff;
+  opacity: .9;
+}
+.nb-explainer__text{ color: var(--nb-ink, #2f3e48); }
+
+/* optional loop diagram spacing */
+.nb-explainer__col--right .nb-loop{
+  margin-top: clamp(12px,2vw,18px);
+  opacity: .9;
+  max-width: 360px;
+}
+

--- a/sections/coaching-service.liquid
+++ b/sections/coaching-service.liquid
@@ -691,162 +691,66 @@
   .nb-midcta{ margin-top: clamp(10px,2vw,16px); text-align: center; }
 </style>
 
-{%- comment -%} EXPLAINER — “What is {{ service.title }} at Nibana?” (placed under trustbelt) {%- endcomment -%}
-{%- liquid
-  assign ex_title = service.explainer_title
-  assign ex_rich  = service.explainer_richtext
+{%- comment -%}
+  Explainer + Challenges panel
+  Uses existing Coaching Service metaobject fields:
+  - service.explainer_title
+  - service.explainer_richtext
+  - service.explainer_points  (multiline: one challenge per line)
+{%- endcomment -%}
 
-  assign ex_bullets_raw = service.explainer_points | append: ''
-  assign ex_html  = ex_bullets_raw | newline_to_br
-  assign br_tag   = '<br />'
-  assign ex_norm  = ex_html | replace: '<br/>', br_tag | replace: '<br>', br_tag | replace: '&nbsp;', ' '
-  assign ex_pipe  = ex_norm | replace: br_tag, '|||'
-  assign ex_items = ex_pipe | split: '|||'
+{%- assign ex_title = service.explainer_title -%}
+{%- assign ex_rich  = service.explainer_richtext -%}
 
-  assign ex_count = 0
-  for it in ex_items
-    assign t = it | strip
-    if t != ''
-      assign ex_count = ex_count | plus: 1
-    endif
-  endfor
-
-  assign _svc_title = service.title | default: 'Transformational Life Coaching'
-  if ex_title != blank
-    assign ex_heading = ex_title
-  else
-    assign ex_heading = 'What is ' | append: _svc_title | append: ' at Nibana?'
-  endif
--%}
-
-{%- if ex_title or ex_rich or ex_count > 0 -%}
-<style>
-  /* ===== Explainer — Editorial Luxe A* ===== */
-  .nb-explainer{
-    background:#fff;
-    border:1px solid #eef2f5;              /* hairline border */
-    border-radius:24px;
-    padding: clamp(22px, 3vw, 36px);
-    box-shadow: 0 30px 80px rgba(0,0,0,.045); /* softer, wider */
-  }
-
-  /* Center the inner content and cap width */
- .nb-explainer__wrap{ max-width: none; margin: 0; }
-
-  /* Heading: a touch lighter for refinement */
-  .nb-explainer__title{
-    margin:0 0 clamp(14px,2.4vw,20px);
-    letter-spacing:-0.01em;
-    font-weight: 600;                       /* down a notch */
-  }
-
-  /* Lede + body copy width cap for editorial feel */
-  .nb-explainer__rte{ max-width: none; }
-  .nb-explainer__rte p:first-child{
-    font-size:clamp(1.02rem,1.1vw,1.15rem);
-    color: rgb(var(--color-foreground-rgb) / 0.80);
-    margin-top: 2px;
-  }
-  .nb-explainer__rte p{
-    color: rgb(var(--color-foreground-rgb) / 0.92);
-    line-height:1.7;
-  }
-
-  /* Bullets → elegant rows (fixed, comfy columns) */
-.nb-explainer__list{
-  list-style:none; margin: clamp(12px,2vw,16px) 0 0; padding:0;
-  display:grid; row-gap: 10px; column-gap: 28px;
-  grid-template-columns: repeat(2, minmax(0,1fr));  /* full-width columns */
-}
-@media (max-width: 900px){
-  .nb-explainer__list{ grid-template-columns:1fr; }
-}
-
- .nb-explainer__li{
-  position:relative;
-  background: transparent;
-  padding: .9rem 0 1rem 2.1rem;   /* room for the dot */
-  line-height: 1.6;
-  transition: transform .28s ease, opacity .28s ease;
-  will-change: transform, opacity;
-}
-
-  /* Gutter rule that starts after the dot (cleaner than full-width border) */
-  .nb-explainer__li::after{
-    content:""; position:absolute; left:2.1rem; right:0; top:0;
-    height:1px; background:#f1f4f6;
-  }
-  /* hide the top rule for the first row in each column */
-  .nb-explainer__li:nth-child(-n+2)::after{ display:none; }
-  @media (max-width: 900px){ .nb-explainer__li:first-child::after{ display:none; } }
-
-  /* Brand dot with halo, aligned to the first line */
-  .nb-explainer__li::before{
-    content:""; position:absolute; left:.6rem; top: .88em;   /* refined align */
-    width:8px; height:8px; border-radius:50%;
-    background: var(--nb-chocolate);
-    box-shadow:0 0 0 6px color-mix(in oklab, var(--nb-chocolate), #fff 88%);
-  }
-
-  /* Micro-interaction: hover/focus lift */
-  .nb-explainer__li:hover,
-  .nb-explainer__li:focus-within{ transform: translateY(-2px); }
-
-  /* On-scroll reveal (honors reduced motion) */
-  @media (prefers-reduced-motion: no-preference){
-    .nb-ex-anim{ opacity:0; transform: translateY(6px); }
-    .nb-ex-anim.in{ opacity:1; transform:none; transition: transform .45s ease, opacity .45s ease; }
-  }
-</style>
-
-<section class="nb-explainer">
-  <div class="nb-shell">
-    <div class="nb-explainer__wrap nb-panel--mint" style="position:relative; padding: clamp(18px, 2.2vw, 26px);" data-anim>
-      <img class="nb-motif nb-motif--tr" src="{{ 'swash-01.svg' | asset_url }}" alt="">
-
-      <h2 class="nb-h2 nb-explainer__title">{{ ex_heading }}</h2>
-
-      {%- if ex_rich -%}
-        <div class="nb-rte nb-explainer__rte">
-          {{ ex_rich | metafield_tag }}
-        </div>
-      {%- endif -%}
-
-      {%- if ex_count > 0 -%}
-  <ul class="nb-explainer__list">
-    {%- for it in ex_items -%}
-      {%- assign t = it | strip -%}
-      {%- if t != '' -%}
-        <li class="nb-explainer__li nb-ex-anim">{{ t }}</li>
-      {%- endif -%}
-    {%- endfor -%}
-  </ul>
+{%- assign ex_points_raw = service.explainer_points | newline_to_br -%}
+{%- assign ex_points = ex_points_raw | split: '<br />' | compact -%}
+{%- assign has_points = false -%}
+{%- if ex_points.size > 0 -%}
+  {%- assign first_point = ex_points[0] | strip -%}
+  {%- if first_point != '' -%}
+    {%- assign has_points = true -%}
+  {%- endif -%}
 {%- endif -%}
+
+<section class="nb-explainer tone-sage" id="nb-explainer-{{ section.id }}">
+  <div class="nb-explainer__wrap">
+    {%- if ex_title != blank -%}
+      <h2 class="nb-explainer__hd">{{ ex_title }}</h2>
+    {%- endif -%}
+
+    <div class="nb-explainer__panel">
+      <div class="nb-explainer__grid {% if has_points %}nb-explainer--two{% else %}nb-explainer--one{% endif %}">
+        <div class="nb-explainer__col nb-explainer__col--left">
+          {%- if ex_rich != blank -%}
+            <div class="nb-explainer__body rte">
+              {{ ex_rich | metafield_tag }}
+            </div>
+          {%- endif -%}
+        </div>
+
+        {%- if has_points -%}
+        <aside class="nb-explainer__col nb-explainer__col--right" aria-label="Common challenges this addresses">
+          <h3 class="nb-explainer__subhd">{{ section.settings.explainer_points_heading }}</h3>
+          <ul class="nb-explainer__list" role="list">
+            {%- for p in ex_points -%}
+              {%- if p != blank -%}
+                <li class="nb-explainer__item">
+                  <span class="nb-explainer__icon" aria-hidden="true"></span>
+                  <span class="nb-explainer__text">{{ p | strip }}</span>
+                </li>
+              {%- endif -%}
+            {%- endfor -%}
+          </ul>
+
+          {%- if section.settings.show_loop_diagram and ex_points.size >= 4 -%}
+            {%- render 'nb-loop-diagram' -%}
+          {%- endif -%}
+        </aside>
+        {%- endif -%}
+      </div>
     </div>
   </div>
 </section>
-<script>
-  (function(){
-    var root = document.querySelector('.nb-explainer');
-    if(!root) return;
-    var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    if(reduce) return;
-    var items = root.querySelectorAll('.nb-ex-anim');
-    if(!items.length) return;
-
-    var io = new IntersectionObserver(function(entries){
-      entries.forEach(function(e){
-        if(e.isIntersecting){
-          e.target.classList.add('in');
-          io.unobserve(e.target);
-        }
-      });
-    }, { rootMargin: '0px 0px -10% 0px', threshold: 0.1 });
-
-    items.forEach(function(el){ io.observe(el); });
-  })();
-</script>
-{%- endif -%}
 
 {%- liquid
   assign oc_raw  = service.outcomes | append: ''
@@ -1550,6 +1454,32 @@
 {%- else -%}
 <section class="page--width" style="padding:40px 0;"><p>No coaching service selected for this page.</p></section>
 {%- endif -%}
+
+{% schema %}
+{
+  "name": "Coaching service",
+  "settings": [
+    {
+      "type": "text",
+      "id": "explainer_points_heading",
+      "label": "Challenges heading",
+      "default": "Common challenges this addresses"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_loop_diagram",
+      "label": "Show loop diagram",
+      "default": true
+    }
+  ],
+  "blocks": [],
+  "presets": [
+    {
+      "name": "Coaching service"
+    }
+  ]
+}
+{% endschema %}
 
 
 

--- a/snippets/nb-loop-diagram.liquid
+++ b/snippets/nb-loop-diagram.liquid
@@ -1,0 +1,35 @@
+{%- comment -%} Slim loop diagram: Pressure → Perform → Numb → Repeat {%- endcomment -%}
+<svg class="nb-loop" viewBox="0 0 360 520" role="img" aria-label="Loop: Pressure, Perform, Numb, Repeat">
+  <defs>
+    <style>
+      .nbl-s { stroke: currentColor; stroke-width: 1; fill: none; }
+      .nbl-t { fill: currentColor; font: 12px/1.2 system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; opacity:.85; }
+    </style>
+  </defs>
+
+  <!-- Nodes -->
+  <circle class="nbl-s" cx="180" cy="60"  r="26"></circle>
+  <text class="nbl-t" x="180" y="60" text-anchor="middle" dominant-baseline="middle">Pressure</text>
+
+  <circle class="nbl-s" cx="300" cy="200" r="26"></circle>
+  <text class="nbl-t" x="300" y="200" text-anchor="middle" dominant-baseline="middle">Perform</text>
+
+  <circle class="nbl-s" cx="180" cy="340" r="26"></circle>
+  <text class="nbl-t" x="180" y="340" text-anchor="middle" dominant-baseline="middle">Numb</text>
+
+  <circle class="nbl-s" cx="60"  cy="200" r="26"></circle>
+  <text class="nbl-t" x="60"  y="200" text-anchor="middle" dominant-baseline="middle">Repeat</text>
+
+  <!-- Arrows -->
+  <path class="nbl-s" d="M200 78 C245 110, 270 140, 290 174"></path>
+  <polygon fill="currentColor" points="296,180 286,176 291,171"></polygon>
+
+  <path class="nbl-s" d="M282 220 C250 262, 220 300, 196 320"></path>
+  <polygon fill="currentColor" points="188,326 193,316 198,321"></polygon>
+
+  <path class="nbl-s" d="M160 322 C120 290, 95 260, 70 226"></path>
+  <polygon fill="currentColor" points="64,218 74,222 69,227"></polygon>
+
+  <path class="nbl-s" d="M78 182 C108 140, 140 110, 164 90"></path>
+  <polygon fill="currentColor" points="172,84 167,94 162,89"></polygon>
+</svg>


### PR DESCRIPTION
## Summary
- set the explainer section to use the sage tone wrapper and add a white card panel so the rich text and challenges grid sit inside an elevated surface
- refresh the explainer utility styles to match the V2 polish spec, including tone tokens, heavier heading, refined bullet ticks, and responsive spacing adjustments
- default the loop diagram checkbox to on so the SVG appears automatically when the bullet count threshold is met

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cecdf4357c83318bc045c553e170af