### PR TITLE
Render loop diagram when enough points

### DIFF
--- a/sections/coaching-service.liquid
+++ b/sections/coaching-service.liquid
@@ -742,7 +742,7 @@
           {%- endfor -%}
         </ul>
 
-        {%- if section.settings.show_loop_diagram and ex_points.size >= 4 -%}
+        {%- if ex_points.size >= 4 -%}
           {%- render 'nb-loop-diagram' -%}
         {%- endif -%}
       </aside>
@@ -1465,12 +1465,6 @@
       "label": "Challenges heading",
       "default": "Common challenges this addresses"
     },
-    {
-      "type": "checkbox",
-      "id": "show_loop_diagram",
-      "label": "Show loop diagram",
-      "default": false
-    }
   ],
   "blocks": [],
   "presets": [


### PR DESCRIPTION
## Summary
- always render the explainer loop diagram when four or more challenge points are provided
- remove the unused loop diagram checkbox from the section settings schema

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cee2fe9df48331be77441476015080