### PR TITLE
Align explainer panel styling with process tray

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -5388,10 +5388,9 @@ body.nb-typography{
 
 /* inner card panel */
 .nb-explainer__panel{
-  background: var(--nb-white, #ffffff);
-  border: 1px solid color-mix(in oklab, var(--nb-ink, #2f3e48), #fff 90%);
-  border-radius: var(--nb-radius-lg, 20px);
-  box-shadow: var(--nb-shadow-1, 0 10px 28px rgba(0,0,0,.06));
+  background: var(--tone-bg, var(--nb-sage, #eaf4f3));
+  border-radius: 18px;
+  box-shadow: 0 10px 26px rgba(0,0,0,.06);
   padding: clamp(22px,2.8vw,34px);
 }
 


### PR DESCRIPTION
## Summary
- update the explainer panel background to use the shared tone variable so it matches the process tray surface
- reuse the process tray radius and shadow to align elevation treatments

## Testing
- not run (Shopify theme preview required)


------
https://chatgpt.com/codex/tasks/task_e_68cee5cca5608331a629b872063b7bb1