### PR TITLE
Restore explainer panel styling

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -5388,9 +5388,8 @@ body.nb-typography{
 
 /* inner card panel */
 .nb-explainer__panel{
-  background: var(--tone-bg, var(--nb-sage, #eaf4f3));
-  border-radius: 18px;
-  box-shadow: 0 10px 26px rgba(0,0,0,.06);
+  background: var(--nb-white, #ffffff);
+  border: 1px solid color-mix(in oklab, var(--nb-ink, #2f3e48), #fff 90%);
   padding: clamp(22px,2.8vw,34px);
 }
 


### PR DESCRIPTION
## Summary
- revert the explainer panel background to the white surface
- restore the subtle ink border while keeping existing padding
- remove radius and shadow from the inner panel so those styles stay on the wrapper

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cee6e627648331b376b5aec4670439