### PR TITLE
Adjust explainer panel styling

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -5363,7 +5363,8 @@ body.nb-typography{
 .nb-explainer{
   /* bigger outer air, consistent with service hero rhythm */
   padding: clamp(56px,7vw,112px) clamp(18px,6vw,96px);
-  border-radius: 22px;
+  border-radius: 18px;
+  box-shadow: 0 10px 26px rgba(0,0,0,.06);
   background: var(--tone-bg, var(--nb-sage, #eaf4f3));
   position: relative;
 }


### PR DESCRIPTION
## Summary
- reduce the explainer shell border radius for a slightly sharper look
- add a soft drop shadow to the explainer container while keeping the tone background

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cee747823c833181813146d432eb69