### PR TITLE
Style coaching explainer columns as cards

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -5389,21 +5389,34 @@ body.nb-typography{
 
 /* inner card panel */
 .nb-explainer__panel{
-  background: var(--nb-white, #ffffff);
-  border: 1px solid color-mix(in oklab, var(--nb-ink, #2f3e48), #fff 90%);
-  padding: clamp(22px,2.8vw,34px);
+  background: transparent;
+  border: 0;
+  padding: clamp(22px,2.8vw,34px) 0 0;
 }
 
 /* grid */
 .nb-explainer__grid{
   display: grid;
-  gap: clamp(18px,2.2vw,28px);
+  gap: clamp(20px,2.6vw,34px);
 }
 .nb-explainer--two{ grid-template-columns: 1.25fr 0.75fr; }
 .nb-explainer--one{ grid-template-columns: 1fr; }
 @media (max-width: 1024px){
   .nb-explainer--two{ grid-template-columns: 1fr; }
 }
+
+.nb-explainer__col{
+  background: var(--nb-white, #ffffff);
+  border-radius: clamp(18px, 2vw, 28px);
+  border: 1px solid color-mix(in oklab, var(--nb-ink, #2f3e48), #fff 88%);
+  box-shadow: 0 14px 34px rgba(16, 24, 40, 0.08);
+  padding: clamp(22px,2.6vw,32px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(14px,2vw,20px);
+}
+
+.nb-explainer__col--right{ align-self: start; }
 
 /* copy */
 .nb-explainer__body p{ margin: 0 0 12px; }
@@ -5412,7 +5425,7 @@ body.nb-typography{
 /* right column header */
 .nb-explainer__subhd{
   font-size: clamp(15px,1.5vw,18px);
-  margin: 2px 0 10px;
+  margin: 0;
   font-weight: 700;
   color: var(--nb-ink, #2f3e48);
 }
@@ -5420,7 +5433,7 @@ body.nb-typography{
 /* list */
 .nb-explainer__list{
   display: grid;
-  gap: 10px;
+  gap: clamp(10px,1.6vw,16px);
   margin: 0;
   padding: 0;
   list-style: none;

--- a/sections/coaching-service.liquid
+++ b/sections/coaching-service.liquid
@@ -720,33 +720,33 @@
 
     <div class="nb-explainer__panel">
       <div class="nb-explainer__grid {% if has_points %}nb-explainer--two{% else %}nb-explainer--one{% endif %}">
-      <div class="nb-explainer__col nb-explainer__col--left">
-        {%- if ex_rich != blank -%}
-          <div class="nb-explainer__body rte">
-            {{ ex_rich | metafield_tag }}
-          </div>
-        {%- endif -%}
-      </div>
+        <div class="nb-explainer__col nb-explainer__col--left">
+          {%- if ex_rich != blank -%}
+            <div class="nb-explainer__body rte">
+              {{ ex_rich | metafield_tag }}
+            </div>
+          {%- endif -%}
+        </div>
 
-      {%- if has_points -%}
-      <aside class="nb-explainer__col nb-explainer__col--right" aria-label="Common challenges this addresses">
-        <h3 class="nb-explainer__subhd">{{ section.settings.explainer_points_heading }}</h3>
-        <ul class="nb-explainer__list" role="list">
-          {%- for p in ex_points -%}
-            {%- if p != blank -%}
-              <li class="nb-explainer__item">
-                <span class="nb-explainer__icon" aria-hidden="true"></span>
-                {{ p | strip }}
-              </li>
+        {%- if has_points -%}
+          <aside class="nb-explainer__col nb-explainer__col--right" aria-label="Common challenges this addresses">
+            <h3 class="nb-explainer__subhd">{{ section.settings.explainer_points_heading }}</h3>
+            <ul class="nb-explainer__list" role="list">
+              {%- for p in ex_points -%}
+                {%- if p != blank -%}
+                  <li class="nb-explainer__item">
+                    <span class="nb-explainer__icon" aria-hidden="true"></span>
+                    {{ p | strip }}
+                  </li>
+                {%- endif -%}
+              {%- endfor -%}
+            </ul>
+
+            {%- if section.settings.show_loop_diagram and ex_points.size >= 4 -%}
+              {%- render 'nb-loop-diagram' -%}
             {%- endif -%}
-          {%- endfor -%}
-        </ul>
-
-        {%- if section.settings.show_loop_diagram and ex_points.size >= 4 -%}
-          {%- render 'nb-loop-diagram' -%}
+          </aside>
         {%- endif -%}
-      </aside>
-      {%- endif -%}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- restyled `.nb-explainer__col` to render each coaching explainer column as an individual white card with rounded corners, inner padding, and upgraded spacing
- relaxed the explainer panel container so the new cards sit directly on the tone background and tuned list spacing for better readability
- cleaned up the section markup so both left and right explainer columns wrap content cleanly inside the new card treatment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cee7eb7da083319850b29fa282e1a2