### PR TITLE
Adjust explainer padding on small screens

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -5369,6 +5369,12 @@ body.nb-typography{
   position: relative;
 }
 
+@media (max-width: 600px){
+  .nb-explainer{ padding-inline: 12px; }
+  .nb-explainer__wrap{ padding-inline: 12px; }
+  .nb-explainer__col{ padding-inline: 14px; }
+}
+
 /* optional tones (explicit) */
 .nb-explainer.tone-white{ --tone-bg: var(--nb-white, #ffffff); }
 .nb-explainer.tone-pebble{ --tone-bg: var(--nb-pebble, #f5f6f4); }


### PR DESCRIPTION
## Summary
- reduce horizontal padding for the explainer module on narrow screens to keep the section compact
- ensure inner wrap and cards also tighten spacing so the module remains within ~90–94% width at 320px

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ceeb9f0fe88331982d59a32c5d4a5d