### PR TITLE
Increase explainer card spacing on mobile

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -5407,6 +5407,9 @@ body.nb-typography{
 }
 .nb-explainer--two{ grid-template-columns: 1.25fr 0.75fr; }
 .nb-explainer--one{ grid-template-columns: 1fr; }
+@media (max-width: 600px){
+  .nb-explainer__grid{ row-gap: clamp(32px,6vw,44px); }
+}
 @media (max-width: 1024px){
   .nb-explainer--two{ grid-template-columns: 1fr; }
 }


### PR DESCRIPTION
## Summary
- ensure the explainer grid rows gain additional spacing on narrow screens so single-column cards stay separated

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ceec35f1f08331bdd256e786a053a7