### PR TITLE
Limit explainer wrap width to shared shell

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -5382,7 +5382,7 @@ body.nb-typography{
 
 /* shell + heading */
 .nb-explainer__wrap{
-  max-width: var(--nb-shell, 1180px);
+  max-width: min(var(--nb-shell, 1180px), var(--nb-shell-w, 94vw));
   margin: 0 auto;
   padding: 0 clamp(16px,2vw,28px);
 }


### PR DESCRIPTION
## Summary
- constrain the explainer wrapper to the shared shell width measurement so it matches other trays

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ceef1f3d3083319adefe3aeebfff18