### PR TITLE
Quiz: fix Mailchimp tags + on-site thank-you + name/phone

### DIFF
--- a/assets/nb-quiz-surgesignature.css
+++ b/assets/nb-quiz-surgesignature.css
@@ -9,3 +9,7 @@
 .nb-quiz__result-title{font-size:24px;margin:0 0 8px}
 .nb-quiz__gate{margin-top:16px}
 .nb-quiz__gdpr{font-size:13px;margin:8px 0}
+
+.nb-quiz__thanks h3{margin-top:0;margin-bottom:8px}
+.nb-quiz__thanks p{margin:6px 0}
+.nb-quiz__result-card{transition:opacity .2s ease}

--- a/sections/nb-quiz-surgesignature.liquid
+++ b/sections/nb-quiz-surgesignature.liquid
@@ -15,6 +15,7 @@
     </div>
     <div class="nb-quiz__app" data-nb-quiz-app hidden></div>
     <div class="nb-quiz__result" data-nb-quiz-result hidden></div>
+    <iframe name="mc-target-{{ section.id }}" class="nb-quiz__mc-frame" style="display:none;"></iframe>
   </div>
 
   <script src="{{ 'nb-quiz-surgesignature.js' | asset_url }}" defer></script>


### PR DESCRIPTION
- Post tags as tags[] to ensure tagging.
- Add hidden iframe target to prevent leaving site; show Nibana-styled thank-you.
- Collect FULLNAME (split to FNAME/LNAME) + optional PHONE.
- Includes u/id passthrough for stricter MC forms.

------
https://chatgpt.com/codex/tasks/task_e_68cfd8b4c9948331a32cd1ce5d5ba471