### PR TITLE
Quiz: enable Interest Groups (guaranteed classification)

### DIFF
--- a/assets/nb-quiz-surgesignature.js
+++ b/assets/nb-quiz-surgesignature.js
@@ -52,6 +52,20 @@
 
         const s = quiz.styles[style];
 
+        // ---- BEGIN Mailchimp Group IDs (REAL) ----
+        // Mailchimp Group Category "Lead Source" (checkboxes)
+        const MC_CAT_ID    = '78632';
+        const MC_INT_SURGE = '1'; // Surge Signature Quiz
+        const MC_INT_ACCEL = '2'; // Accelerator
+        const MC_INT_STABL = '4'; // Stabiliser
+        const MC_INT_DEFUS = '8'; // Defuser
+        // Map computed style -> interest ID
+        let styleInterest = '';
+        if (style === 'accelerator') styleInterest = MC_INT_ACCEL;
+        else if (style === 'stabilizer' || style === 'stabiliser') styleInterest = MC_INT_STABL;
+        else if (style === 'defuser') styleInterest = MC_INT_DEFUS;
+        // ---- END Mailchimp Group IDs ----
+
         // Parse u & id from the Mailchimp action URL
         const act = document.createElement('a');
         act.href = cfg.mailchimpAction;
@@ -94,6 +108,9 @@
               <input type="hidden" name="tags[]" value="Quiz: Surge Signature">
               <input type="hidden" name="tags[]" value="Source: /surge-signature">
               <input type="hidden" name="tags[]" value="Style: ${s.title}">
+
+              <input type="checkbox" name="group[${MC_CAT_ID}][${MC_INT_SURGE}]" value="1" checked hidden>
+              ${styleInterest ? `<input type="checkbox" name="group[${MC_CAT_ID}][${styleInterest}]" value="1" checked hidden>` : ''}
 
               <!-- Redundant tag fields to ensure Mailchimp tagging -->
               <input type="hidden" name="tags" value="Surge Signature Quiz">


### PR DESCRIPTION
- Adds hidden checkboxes for Mailchimp Groups: Lead Source (Surge Signature Quiz) and style-specific.
- Uses Category ID 78632 and Interest IDs 1,2,4,8 from Mailchimp embed code.
- Keeps on-site thank-you, STYLE merge field, and GA4 events intact.

------
https://chatgpt.com/codex/tasks/task_e_68cfe14224e88331b5de40b6a071894d