### PR TITLE
Surge Signature™ — result page

### DIFF
--- a/assets/nb-quiz-result.js
+++ b/assets/nb-quiz-result.js
@@ -1,0 +1,71 @@
+(function(){
+  function qs(name){ const u=new URL(window.location.href); return (u.searchParams.get(name)||'').toLowerCase(); }
+  function html(s){ const d=document.createElement('div'); d.innerHTML=s; return d.firstElementChild; }
+  function dl(event, params){ window.dataLayer = window.dataLayer || []; window.dataLayer.push(Object.assign({event}, params||{})); }
+
+  document.addEventListener('DOMContentLoaded', async function(){
+    const root = document.querySelector('[data-nb-result-app]');
+    if(!root) return;
+
+    const style = qs('style'); // accelerator | stabilizer | defuser
+    const jsonUrl = root.getAttribute('data-json');
+    const callHref = root.getAttribute('data-call-href') || '/pages/book-a-call';
+    const retakeHref = root.getAttribute('data-retake-href') || '/pages/surge-signature';
+
+    let data;
+    try{
+      const res = await fetch(jsonUrl, { credentials:'same-origin' });
+      data = await res.json();
+    }catch(e){
+      root.innerHTML = '<div class="nb-card">Could not load results.</div>';
+      return;
+    }
+
+    const s = data.styles[style];
+    if(!s){
+      root.innerHTML = `
+        <div class="nb-card">
+          <h3 style="margin-top:0">Pick your result</h3>
+          <p>Use one of these:</p>
+          <ul>
+            <li><a href="?style=accelerator">Accelerator</a></li>
+            <li><a href="?style=stabilizer">Stabilizer</a></li>
+            <li><a href="?style=defuser">Defuser</a></li>
+          </ul>
+        </div>`;
+      return;
+    }
+
+    dl('quiz_result_view', { quiz: 'surge_signature', style: style });
+
+    const card = `
+      <div class="nb-card nb-result">
+        <p class="nb-quiz__result-kicker">Your Surge Signature™</p>
+        <h1 class="nb-quiz__result-title">${s.title}</h1>
+        <p class="nb-quiz__summary">${s.summary}</p>
+
+        ${s.exalted ? `<div class="nb-result__block"><h3>Exalted form</h3><p>${s.exalted}</p></div>` : ''}
+
+        ${Array.isArray(s.pitfalls) ? `
+          <div class="nb-result__block">
+            <h3>Watch-outs</h3>
+            <ul class="nb-list">
+              ${s.pitfalls.map(p=>`<li>${p}</li>`).join('')}
+            </ul>
+          </div>` : ''}
+
+        ${s.practice_preview ? `
+          <div class="nb-result__block">
+            <h3>Try this today</h3>
+            <p>${s.practice_preview}</p>
+          </div>` : ''}
+
+        <div class="nb-result__cta">
+          <a class="nb-btn nb-btn--primary" href="${callHref}">Book a 20-min Clarity Call</a>
+          <a class="nb-btn nb-btn--ghost" href="${retakeHref}">Retake the quiz</a>
+        </div>
+      </div>
+    `;
+    root.innerHTML = card;
+  });
+})();

--- a/assets/nb-quiz-surgesignature.css
+++ b/assets/nb-quiz-surgesignature.css
@@ -17,3 +17,7 @@
 .nb-quiz__gate input[type="text"],
 .nb-quiz__gate input[type="email"],
 .nb-quiz__gate input[type="tel"]{width:100%}
+.nb-result .nb-quiz__result-title{font-size:clamp(28px,4vw,40px);margin:0 0 8px}
+.nb-result__block{margin-top:16px}
+.nb-result__cta{display:grid;grid-template-columns:1fr;gap:10px;margin-top:18px}
+.nb-btn--ghost{background:#fff;border:1px solid #dfe7e6}

--- a/sections/nb-quiz-result.liquid
+++ b/sections/nb-quiz-result.liquid
@@ -1,0 +1,26 @@
+{% comment %}
+  Surge Signature™ Result (reads ?style=accelerator|stabilizer|defuser)
+  Uses assets/nb-quiz-surgesignature.json as content source.
+{% endcomment %}
+<section id="nb-result-{{ section.id }}" class="nb-result nb-result--surgesignature">
+  <div class="nb-shell">
+    <div data-nb-result-app
+         data-json="{{ 'nb-quiz-surgesignature.json' | asset_url }}"
+         data-call-href="{{ section.settings.call_href }}"
+         data-retake-href="{{ section.settings.retake_href }}"></div>
+  </div>
+  <script src="{{ 'nb-quiz-result.js' | asset_url }}" defer></script>
+  <link rel="stylesheet" href="{{ 'nb-quiz-surgesignature.css' | asset_url }}" media="all">
+</section>
+
+{% schema %}
+{
+  "name": "Surge Result",
+  "settings": [
+    { "type": "text", "id": "call_href", "label": "Book a call URL", "default": "/pages/book-a-call" },
+    { "type": "text", "id": "retake_href", "label": "Retake quiz URL", "default": "/pages/surge-signature" }
+  ],
+  "blocks": [],
+  "presets": [{ "name": "Surge Result" }]
+}
+{% endschema %}

--- a/templates/page.surge-signature-result.json
+++ b/templates/page.surge-signature-result.json
@@ -1,0 +1,12 @@
+{
+  "sections": {
+    "main": {
+      "type": "nb-quiz-result",
+      "settings": {
+        "call_href": "/pages/book-a-call",
+        "retake_href": "/pages/surge-signature"
+      }
+    }
+  },
+  "order": ["main"]
+}


### PR DESCRIPTION
- Adds results page at template page.surge-signature-result.
- Reads ?style=accelerator|stabilizer|defuser and renders from JSON.
- Adds GA4 event quiz_result_view; CTAs for call + retake; uses nb-shell.

------
https://chatgpt.com/codex/tasks/task_e_68cfe90ecb848331af21f58f0c71444a