### PR TITLE
Surge Signature™ — Lux styling pass

### DIFF
--- a/assets/nb-quiz-surgesignature.css
+++ b/assets/nb-quiz-surgesignature.css
@@ -1,23 +1,148 @@
-.nb-shell{max-width:960px;margin:0 auto;padding:clamp(12px,3vw,24px);}
-.nb-card{background:#EAF4F3;border-radius:16px;padding:24px;box-shadow:0 6px 18px rgba(0,0,0,.06);}
-.nb-quiz__title{margin:0 0 8px;}
-.nb-quiz__kicker{opacity:.8;margin:0 0 16px;}
-.nb-btn{display:block;width:100%;padding:12px 16px;border-radius:12px;border:0;cursor:pointer}
-.nb-btn--primary{background:#10636c;color:#fff}
-.nb-btn--option{background:#fff;margin:8px 0;text-align:left;border:1px solid #dfe7e6}
-.nb-quiz__progress{font-size:14px;margin-bottom:8px;opacity:.7}
-.nb-quiz__result-title{font-size:24px;margin:0 0 8px}
-.nb-quiz__gate{margin-top:16px}
-.nb-quiz__gdpr{font-size:13px;margin:8px 0}
+/* ===== Nibana — Surge Signature (lux styling) ===== */
+:root{
+  --nb-shell-w: 960px;
+  --nb-panel-bg: #EAF4F3;
+  --nb-panel-border: rgba(16, 99, 108, .10);
+  --nb-shadow: 0 20px 50px rgba(0,0,0,.06);
+  --nb-radius-xl: 24px;
+  --nb-radius-md: 12px;
+  --nb-space-1: 8px;
+  --nb-space-2: 12px;
+  --nb-space-3: 16px;
+  --nb-space-4: 20px;
+  --nb-space-5: 24px;
+  --nb-space-6: 32px;
+  --nb-space-7: 40px;
+  --nb-text-muted: rgba(0,0,0,.65);
+  --nb-text-soft: rgba(0,0,0,.55);
+  --nb-primary: #10636c;     /* deep teal */
+  --nb-primary-hover: #0f5b63;
+  --nb-primary-active: #0d4e56;
+  --nb-option-bg: #fff;
+  --nb-option-border: #dfe7e6;
+  --nb-focus: #0f6d77;
+}
 
-.nb-quiz__thanks h3{margin-top:0;margin-bottom:8px}
-.nb-quiz__thanks p{margin:6px 0}
-.nb-quiz__result-card{transition:opacity .2s ease}
-.nb-quiz__gate label{display:block}
+/* Layout shell */
+.nb-shell{max-width:var(--nb-shell-w);margin:0 auto;padding:clamp(24px,6vw,72px) clamp(12px,3vw,24px);}
+
+/* Panel / card */
+.nb-card{
+  background:var(--nb-panel-bg);
+  border:1px solid var(--nb-panel-border);
+  border-radius:var(--nb-radius-xl);
+  box-shadow:var(--nb-shadow);
+  padding:clamp(var(--nb-space-5),3vw,var(--nb-space-7));
+}
+
+/* Headings & copy */
+.nb-quiz__title{
+  font-size:clamp(32px,6vw,56px);
+  line-height:1.1;
+  margin:0 0 var(--nb-space-2);
+  letter-spacing:-.02em;
+}
+.nb-quiz__kicker{margin:0 0 var(--nb-space-4); color:var(--nb-text-soft);}
+.nb-quiz__trust{margin-top:var(--nb-space-3); color:var(--nb-text-soft);}
+.nb-quiz__prompt{
+  font-size:clamp(22px,3.2vw,32px);
+  line-height:1.25;
+  margin:0 0 var(--nb-space-4);
+  font-weight:700;
+}
+
+/* Progress pill */
+.nb-quiz__progress{
+  display:inline-block;
+  font-size:13px;
+  padding:4px 8px;
+  border-radius:999px;
+  background:#fff;
+  border:1px solid var(--nb-panel-border);
+  color:var(--nb-text-soft);
+  margin-bottom:var(--nb-space-3);
+}
+
+/* Buttons */
+.nb-btn{
+  display:block; width:100%;
+  padding:14px 16px; border-radius:var(--nb-radius-md);
+  border:1px solid transparent; cursor:pointer;
+  transition:transform .2s cubic-bezier(.2,.8,.2,1), box-shadow .2s cubic-bezier(.2,.8,.2,1), background-color .2s;
+}
+.nb-btn--primary{
+  background:var(--nb-primary); color:#fff; border-color:var(--nb-primary);
+  box-shadow:0 6px 18px rgba(16,99,108,.15);
+}
+.nb-btn--primary:hover{ background:var(--nb-primary-hover); transform:translateY(-1px); }
+.nb-btn--primary:active{ background:var(--nb-primary-active); transform:translateY(0); }
+
+.nb-btn--option{
+  background:var(--nb-option-bg);
+  border-color:var(--nb-option-border);
+  text-align:left;
+  margin:var(--nb-space-2) 0;
+  box-shadow:0 2px 8px rgba(0,0,0,.03);
+}
+.nb-btn--option:hover{ background:#f7fbfb; border-color:#c9d8d6; transform:translateY(-1px); box-shadow:0 6px 16px rgba(0,0,0,.06); }
+.nb-btn--option:active{ transform:translateY(0); }
+
+/* Focus rings (WCAG) */
+.nb-btn:focus-visible,
+.nb-quiz__gate input:focus-visible,
+.nb-quiz__gdpr input:focus-visible{
+  outline:2px solid var(--nb-focus);
+  outline-offset:2px;
+  box-shadow:0 0 0 2px #fff, 0 0 0 4px var(--nb-focus);
+}
+
+/* Form (result gate) */
+.nb-quiz__gate{margin-top:var(--nb-space-5);}
+.nb-quiz__gate label{display:block; font-size:14px; color:var(--nb-text-muted);}
 .nb-quiz__gate input[type="text"],
 .nb-quiz__gate input[type="email"],
-.nb-quiz__gate input[type="tel"]{width:100%}
-.nb-result .nb-quiz__result-title{font-size:clamp(28px,4vw,40px);margin:0 0 8px}
-.nb-result__block{margin-top:16px}
-.nb-result__cta{display:grid;grid-template-columns:1fr;gap:10px;margin-top:18px}
-.nb-btn--ghost{background:#fff;border:1px solid #dfe7e6}
+.nb-quiz__gate input[type="tel"]{
+  width:100%; height:50px;
+  border-radius:var(--nb-radius-md);
+  border:1px solid var(--nb-option-border);
+  background:#fff; padding:0 14px; margin-top:6px;
+}
+.nb-quiz__gate input:hover{ border-color:#c9d8d6; }
+.nb-quiz__gate input:focus-visible{ border-color:var(--nb-focus); }
+
+/* GDPR */
+.nb-quiz__gdpr{font-size:13px; color:var(--nb-text-soft); margin:var(--nb-space-3) 0 var(--nb-space-4);}
+.nb-quiz__gdpr label{display:flex; align-items:center; gap:10px;}
+
+/* Result view (inside quiz) */
+.nb-quiz__result-title{font-size:clamp(26px,3.6vw,40px); margin:0 0 var(--nb-space-2); font-feature-settings:"liga" 1,"kern" 1;}
+.nb-quiz__summary{color:var(--nb-text-muted); margin:0 0 var(--nb-space-3);}
+.nb-quiz__free-insight{background:#fff; border:1px solid var(--nb-panel-border); border-radius:var(--nb-radius-md); padding:var(--nb-space-3);}
+
+/* On-site thank you */
+.nb-quiz__thanks{ background:rgba(255,255,255,.6); border:1px solid var(--nb-panel-border); border-radius:var(--nb-radius-xl); }
+.nb-quiz__thanks h3{margin:0 0 var(--nb-space-2); font-size:clamp(22px,3vw,28px);}
+.nb-quiz__thanks p{margin:6px 0; color:var(--nb-text-muted);}
+.nb-quiz__thanks a{ text-decoration:underline; }
+
+/* Result page (page.surge-signature-result) */
+.nb-result .nb-quiz__result-title{font-size:clamp(32px,4.5vw,52px); margin:0 0 var(--nb-space-2);}
+.nb-result .nb-quiz__result-kicker{color:var(--nb-text-soft); margin-bottom:var(--nb-space-3);}
+.nb-result .nb-quiz__summary{color:var(--nb-text-muted); margin:0 0 var(--nb-space-5);}
+.nb-result__block{margin-top:var(--nb-space-5);}
+.nb-result__block h3{font-size:clamp(20px,2.6vw,24px); margin:0 0 var(--nb-space-2);}
+.nb-list{margin:0; padding-left:var(--nb-space-6);}
+.nb-result__cta{display:grid; grid-template-columns:1fr; gap:12px; margin-top:var(--nb-space-6);}
+.nb-btn--ghost{background:#fff; border:1px solid var(--nb-option-border); color:#333;}
+.nb-btn--ghost:hover{background:#f7fbfb;}
+
+/* Utilities */
+@media (prefers-reduced-motion: reduce){
+  .nb-btn{transition:none}
+}
+
+/* Keep legacy selectors (from MVP) so nothing breaks */
+.nb-quiz__result-card{transition:opacity .2s ease}
+.nb-quiz__kicker{opacity:.85}
+
+/* End of lux styling */


### PR DESCRIPTION
- Replaces quiz/result CSS with airy, luxurious styling: mint panels, hairline borders, soft depth.
- Upgrades typography scale, spacing, progress pill, option states, focus rings, and form visuals.
- Includes result-page block styling & ghost button; respects reduced motion; no Liquid/JS changes.

------
https://chatgpt.com/codex/tasks/task_e_68cff114256c8331b058af9c6e8f5ba5