### PR TITLE
Polish Surge Signature quiz intro styling

### DIFF
--- a/assets/nb-quiz-surgesignature.css
+++ b/assets/nb-quiz-surgesignature.css
@@ -35,15 +35,25 @@
   padding:clamp(var(--nb-space-5),3vw,var(--nb-space-7));
 }
 
+.nb-quiz__header{
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  text-align:center;
+  gap:var(--nb-space-3);
+  margin-bottom:clamp(var(--nb-space-6),5vw,var(--nb-space-7));
+}
+
 /* Headings & copy */
 .nb-quiz__title{
   font-size:clamp(32px,6vw,56px);
   line-height:1.1;
   margin:0 0 var(--nb-space-2);
   letter-spacing:-.02em;
+  color:var(--nb-primary);
 }
-.nb-quiz__kicker{margin:0 0 var(--nb-space-4); color:var(--nb-text-soft);}
-.nb-quiz__trust{margin-top:var(--nb-space-3); color:var(--nb-text-soft);}
+.nb-quiz__kicker{margin:0 0 var(--nb-space-4); color:var(--nb-primary);}
+.nb-quiz__trust{margin-top:var(--nb-space-3); color:var(--nb-primary);}
 .nb-quiz__prompt{
   font-size:clamp(22px,3.2vw,32px);
   line-height:1.25;
@@ -69,6 +79,10 @@
   padding:14px 16px; border-radius:var(--nb-radius-md);
   border:1px solid transparent; cursor:pointer;
   transition:transform .2s cubic-bezier(.2,.8,.2,1), box-shadow .2s cubic-bezier(.2,.8,.2,1), background-color .2s;
+}
+.nb-quiz__header .nb-btn{
+  max-inline-size:280px;
+  margin-inline:auto;
 }
 .nb-btn--primary{
   background:var(--nb-primary); color:#fff; border-color:var(--nb-primary);

--- a/sections/nb-quiz-surgesignature.liquid
+++ b/sections/nb-quiz-surgesignature.liquid
@@ -5,7 +5,7 @@
 {% endcomment %}
 <section id="nb-quiz-{{ section.id }}" class="nb-quiz nb-quiz--surgesignature" data-section-id="{{ section.id }}">
   <div class="nb-shell">
-    <div class="nb-quiz__header">
+    <div class="nb-quiz__header nb-card">
       <h2 class="nb-quiz__title">{{ section.settings.title | escape }}</h2>
       <p class="nb-quiz__kicker">{{ section.settings.kicker | escape }}</p>
       <button class="nb-btn nb-btn--primary" data-nb-quiz-start>


### PR DESCRIPTION
## Summary
- wrap the quiz intro container in the nb-card treatment to match other surfaces
- center and space the intro header layout while constraining the CTA button width
- refresh intro typography colors to use the brand teal palette

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cff386e4548331a8312ffb93c075d5