### PR TITLE
Adjust surge signature quiz shell spacing

### DIFF
--- a/assets/nb-quiz-surgesignature.css
+++ b/assets/nb-quiz-surgesignature.css
@@ -26,6 +26,11 @@
 /* Layout shell */
 .nb-shell{max-width:var(--nb-shell-w);margin:0 auto;padding:clamp(24px,6vw,72px) clamp(12px,3vw,24px);}
 
+.nb-quiz.nb-quiz--surgesignature .nb-shell,
+.nb-result.nb-result--surgesignature .nb-shell{
+  padding-block-start:clamp(80px,10vw,140px);
+}
+
 /* Panel / card */
 .nb-card{
   background:var(--nb-panel-bg);


### PR DESCRIPTION
## Summary
- add Surge Signature specific shell override to increase top padding for quiz and result layouts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cff64d209c8331920685f787a873a5