### PR TITLE
Adjust Surge Signature quiz spacing

### DIFF
--- a/assets/nb-quiz-surgesignature.css
+++ b/assets/nb-quiz-surgesignature.css
@@ -24,16 +24,7 @@
 }
 
 /* Layout shell */
-.nb-shell{max-width:var(--nb-shell-w);margin:0 auto;padding:clamp(24px,6vw,72px) clamp(12px,3vw,24px);}
-
-.nb-quiz.nb-quiz--surgesignature .nb-shell,
-.nb-result.nb-result--surgesignature .nb-shell{
-  /* Override base top padding while preserving horizontal and bottom spacing */
-  padding:
-    clamp(80px,10vw,140px)
-    clamp(12px,3vw,24px)
-    clamp(24px,6vw,72px);
-}
+.nb-shell{max-width:var(--nb-shell-w);margin:0 auto;padding-inline:clamp(12px,3vw,24px);}
 
 /* Panel / card */
 .nb-card{

--- a/sections/nb-quiz-result.liquid
+++ b/sections/nb-quiz-result.liquid
@@ -2,7 +2,7 @@
   Surge Signature™ Result (reads ?style=accelerator|stabilizer|defuser)
   Uses assets/nb-quiz-surgesignature.json as content source.
 {% endcomment %}
-<section id="nb-result-{{ section.id }}" class="nb-result nb-result--surgesignature">
+<section id="nb-result-{{ section.id }}" class="nb-result nb-result--surgesignature" style="padding-block-start: clamp(80px, 10vw, 140px); padding-block-end: clamp(24px, 6vw, 72px); padding-inline: clamp(12px, 3vw, 24px);">
   <div class="nb-shell">
     <div data-nb-result-app
          data-json="{{ 'nb-quiz-surgesignature.json' | asset_url }}"

--- a/sections/nb-quiz-surgesignature.liquid
+++ b/sections/nb-quiz-surgesignature.liquid
@@ -3,7 +3,7 @@
   - Client-side quiz with soft gate and Mailchimp POST.
   - GA4 events: quiz_start, quiz_question_view, quiz_complete, quiz_result, email_submit.
 {% endcomment %}
-<section id="nb-quiz-{{ section.id }}" class="nb-quiz nb-quiz--surgesignature" data-section-id="{{ section.id }}">
+<section id="nb-quiz-{{ section.id }}" class="nb-quiz nb-quiz--surgesignature" data-section-id="{{ section.id }}" style="padding-block-start: clamp(80px, 10vw, 140px); padding-block-end: clamp(24px, 6vw, 72px); padding-inline: clamp(12px, 3vw, 24px);">
   <div class="nb-shell">
     <div class="nb-quiz__header nb-card">
       <h2 class="nb-quiz__title">{{ section.settings.title | escape }}</h2>


### PR DESCRIPTION
## Summary
- add section-level padding clamps to the Surge Signature quiz and result sections to align with contact page spacing
- adjust the Surge Signature stylesheet so the layout shell only manages width and horizontal padding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d002a9820c8331a163356c9d713827