### PR TITLE
Restore quiz email form validation

### DIFF
--- a/assets/nb-quiz-surgesignature.js
+++ b/assets/nb-quiz-surgesignature.js
@@ -81,7 +81,7 @@
 
         const emailForm = `
     <div data-nb-quiz-form>
-      <form id="nb-quiz-sub" action="${actionWithParams}" method="post" target="mc-target-${section.dataset.sectionId}" novalidate>
+      <form id="nb-quiz-sub" action="${actionWithParams}" method="post" target="mc-target-${section.dataset.sectionId}">
         <p class="nb-quiz__result-kicker">Your Surge Signature™</p>
         <h3 class="nb-quiz__result-title">${s.title}</h3>
         <p class="nb-quiz__summary">${s.summary}</p>
@@ -162,7 +162,11 @@
 
         // Fallback: reveal after 1500ms post-submit in case load is slow
         let thanksTimer = null;
-        sub.addEventListener('submit', function(){
+        sub.addEventListener('submit', function(event){
+          if (!sub.reportValidity()) {
+            event.preventDefault();
+            return;
+          }
           if (thanksTimer) clearTimeout(thanksTimer);
           thanksTimer = setTimeout(showThanks, 1500);
         });


### PR DESCRIPTION
## Summary
- remove the `novalidate` attribute from the quiz email capture form so browser-required fields run again
- guard the fallback thank-you timer behind a validity check to avoid showing it when submission fails

## Testing
- Manual verification (leave required fields blank keeps submission blocked and the thank-you card hidden; valid submission transitions normally)


------
https://chatgpt.com/codex/tasks/task_e_68d00560c6e48331909872ef0245a630