### PR TITLE
Style thank-you CTA button

### DIFF
--- a/assets/nb-quiz-surgesignature.css
+++ b/assets/nb-quiz-surgesignature.css
@@ -138,6 +138,11 @@
 .nb-quiz__thanks h3{margin:0 0 var(--nb-space-2); font-size:clamp(22px,3vw,28px);}
 .nb-quiz__thanks p{margin:6px 0; color:var(--nb-text-muted);}
 .nb-quiz__thanks a{ text-decoration:underline; }
+.nb-quiz__thanks a.nb-btn{ text-decoration:none; }
+.nb-quiz__thanks .nb-btn{
+  margin:var(--nb-space-4) auto 0;
+  max-width:320px;
+}
 
 /* Result page (page.surge-signature-result) */
 .nb-result .nb-quiz__result-title{font-size:clamp(32px,4.5vw,52px); margin:0 0 var(--nb-space-2);}

--- a/assets/nb-quiz-surgesignature.js
+++ b/assets/nb-quiz-surgesignature.js
@@ -124,7 +124,9 @@
       <h3>Check your inbox ✉️</h3>
       <p>We’ve sent your 2-page playbook. If it’s not there, check Promotions/Spam.</p>
       <p><a href="/pages/surge-signature-result?style=${style}">View your result on Nibana →</a></p>
-      <p>Want help applying it? <a href="/pages/book-a-call">Book a 20-min Clarity Call</a>.</p>
+      <div class="nb-quiz__thanks-cta">
+        <a class="nb-btn nb-btn--primary" href="/pages/book-a-call">Book a 20-min Clarity Call</a>
+      </div>
     </div>
   `;
 


### PR DESCRIPTION
## Summary
- update the thank-you view in the Surge Signature quiz so the clarity-call link uses the standard primary button styling
- add thank-you specific button layout rules to keep the CTA centered and comfortably spaced beneath the copy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d00d992f3c8331a74b240cac29079b