### PR TITLE
Use neutral background for surge signature quiz

### DIFF
--- a/assets/nb-quiz-surgesignature.css
+++ b/assets/nb-quiz-surgesignature.css
@@ -28,9 +28,7 @@
 .nb-result--surgesignature{
   position:relative;
   min-height:100vh;
-  background:
-    radial-gradient(120% 120% at 20% 0%, rgba(255,255,255,.92) 0%, rgba(234,244,243,.88) 48%, rgba(200,224,223,.82) 100%),
-    linear-gradient(180deg, #f5fbfa 0%, #e0efee 100%);
+  background:var(--nb-pebble, #f5f6f4);
   background-repeat:no-repeat;
 }
 .nb-shell{max-width:var(--nb-shell-w);margin:0 auto;padding-inline:clamp(12px,3vw,24px);}


### PR DESCRIPTION
## Summary
- replace the Surge Signature quiz and result page gradient background with the neutral pebble surface color
- preserve the 100vh minimum height so the layout shell spacing remains unchanged

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d01303e0888331927813c4c06a8903