### PR TITLE
Quiz microcopy + result blurb

### DIFF
--- a/assets/nb-quiz-surgesignature.js
+++ b/assets/nb-quiz-surgesignature.js
@@ -9,6 +9,21 @@
       const resultEl = section.querySelector('[data-nb-quiz-result]');
       let quiz = null, state = { index: 0, answers: [] }, startedAt = 0;
 
+      // --- Microcopy / A11y hint ---
+      (function(){
+        const shell = section.querySelector('.nb-shell');
+        if (!shell) return;
+        // Add a visually-hidden hint once
+        if (!section.querySelector('[data-nb-quiz-a11y]')) {
+          const hint = document.createElement('div');
+          hint.setAttribute('data-nb-quiz-a11y','');
+          hint.setAttribute('aria-hidden','true');
+          hint.style.position = 'absolute'; hint.style.left = '-9999px';
+          hint.textContent = 'Hint: Use arrow keys to move, Enter to select.';
+          shell.prepend(hint);
+        }
+      })();
+
       try {
         const memStyle = localStorage.getItem('nb_surge_style');
         if (memStyle && ['accelerator','stabilizer','defuser'].includes(memStyle)) {
@@ -43,18 +58,24 @@
         return res.json();
       }
 
+      function setProgressLabel(index, total){
+        const pill = section.querySelector('.nb-quiz__progress');
+        if (pill) pill.textContent = `Question ${index} of ${total}`;
+      }
+
       function renderQuestion(){
         const q = quiz.questions[state.index];
         appEl.innerHTML = `
           <div class="nb-card">
             <div class="nb-quiz__progress" role="progressbar" aria-valuemin="0" aria-valuemax="${quiz.questions.length}" aria-valuenow="${state.index+1}">
-              ${state.index+1}/${quiz.questions.length}
+              Question ${state.index+1} of ${quiz.questions.length}
             </div>
             <h3 class="nb-quiz__prompt" aria-live="polite">${q.prompt}</h3>
             <div class="nb-quiz__options">
               ${q.options.map((o,i)=>`<button class="nb-btn nb-btn--option" data-value="${o.value}" data-i="${i}">${o.label}</button>`).join('')}
             </div>
           </div>`;
+        setProgressLabel(state.index+1, quiz.questions.length);
         dl('quiz_question_view', { index: state.index+1, quiz: cfg.gaNamespace });
         appEl.querySelectorAll('.nb-btn--option').forEach(b=>{
           b.addEventListener('click', ()=>{
@@ -229,6 +250,7 @@
         dl('quiz_start', { quiz: cfg.gaNamespace });
         appEl.hidden = false;
         renderQuestion();
+        setProgressLabel(state.index+1, quiz.questions.length);
         const header = section.querySelector('.nb-quiz__header');
         if (header) header.style.display = 'none';
       });

--- a/sections/nb-quiz-result.liquid
+++ b/sections/nb-quiz-result.liquid
@@ -9,6 +9,13 @@
          data-call-href="{{ section.settings.call_href }}"
          data-retake-href="{{ section.settings.retake_href }}"
          data-force-style="{{ section.settings.force_style }}"></div>
+    {% if section.settings.about_blurb != blank %}
+      <div class="nb-card" style="margin-top:16px">
+        <div class="prose" style="color: rgba(0,0,0,.70);">
+          {{ section.settings.about_blurb }}
+        </div>
+      </div>
+    {% endif %}
   </div>
   <script src="{{ 'nb-quiz-result.js' | asset_url }}" defer></script>
   <link rel="stylesheet" href="{{ 'nb-quiz-surgesignature.css' | asset_url }}" media="all">
@@ -25,7 +32,8 @@
       { "value": "accelerator", "label": "Accelerator" },
       { "value": "stabilizer", "label": "Stabilizer" },
       { "value": "defuser", "label": "Defuser" }
-    ] }
+    ] },
+    { "type": "richtext", "id": "about_blurb", "label": "About the model", "default": "<p>Surge Signature™ maps how your energy moves when the stakes rise. It’s built to be practical: a short reflection, three watch-outs, and simple practices you can use today. Use it with curiosity; retake in a month and notice what shifts.</p>" }
   ],
   "blocks": [],
   "presets": [{ "name": "Surge Result" }]


### PR DESCRIPTION
- Adds a11y hint and ensures progress reads “Question X of N”.
- Adds editable “About the model” rich-text block on the result template.
- Landing/FAQ remain in global sections to keep styling consistent.

------
https://chatgpt.com/codex/tasks/task_e_68d0337c2e60833196cb79ee569b033e