### PR TITLE
Quiz: intro paragraph inside card

### DIFF
--- a/assets/nb-quiz-surgesignature.css
+++ b/assets/nb-quiz-surgesignature.css
@@ -240,3 +240,6 @@
 @media (min-width: 640px){ .nb-result__share{grid-template-columns:repeat(4,1fr);} }
 .nb-quiz__mem{display:flex;flex-direction:column;gap:12px}
 .nb-quiz__mem-actions{display:grid;grid-template-columns:1fr 1fr auto;gap:10px}
+
+.nb-quiz__intro{ margin:12px 0 16px; color:var(--nb-text-muted); }
+.nb-quiz__intro p{ margin:0; }

--- a/sections/nb-quiz-surgesignature.liquid
+++ b/sections/nb-quiz-surgesignature.liquid
@@ -8,6 +8,11 @@
     <div class="nb-quiz__header nb-card">
       <h2 class="nb-quiz__title">{{ section.settings.title | escape }}</h2>
       <p class="nb-quiz__kicker">{{ section.settings.kicker | escape }}</p>
+      {% if section.settings.intro_richtext != blank %}
+        <div class="nb-quiz__intro rte">
+          {{ section.settings.intro_richtext }}
+        </div>
+      {% endif %}
       <button class="nb-btn nb-btn--primary" data-nb-quiz-start>
         {{ section.settings.cta_label | default: 'Start the Quiz' }}
       </button>
@@ -49,7 +54,12 @@
       ]
     },
     { "type": "checkbox", "id": "enable_gdpr", "label": "Show GDPR consent block", "default": true },
-    { "type": "text", "id": "palette", "label": "Palette token (optional)", "default": "nibana" }
+    { "type": "text", "id": "palette", "label": "Palette token (optional)", "default": "nibana" },
+    { "type": "richtext",
+      "id": "intro_richtext",
+      "label": "Intro (short)",
+      "default": "<p>15 quick questions to mirror how your energy moves when the stakes rise. You\u2019ll see your style with strengths, watch-outs, and a practice to try now; we\u2019ll email the full 2\u2011page playbook.</p>"
+    }
   ],
   "blocks": [],
   "presets": [{ "name": "Surge Signature Quiz" }]


### PR DESCRIPTION
- Adds editable rich-text “Intro (short)” to the quiz card header (before Start).
- Uses existing card/nb- styles; auto-hides with the header on Start.
- CSS is append-only; no logic or schema breakage.

------
https://chatgpt.com/codex/tasks/task_e_68d108dcd3c88331b3833dfbbcce877c