### PR TITLE
Adjust surge signature quiz min height

### DIFF
--- a/assets/nb-quiz-surgesignature.css
+++ b/assets/nb-quiz-surgesignature.css
@@ -28,9 +28,12 @@
 .nb-quiz.nb-quiz--surgesignature,
 .nb-result--surgesignature{
   position:relative;
-  min-height:100vh;
   background:var(--nb-pebble, #f5f6f4);
   background-repeat:no-repeat;
+}
+
+.nb-quiz.nb-quiz--surgesignature{
+  min-height:auto;
 }
 .nb-shell{max-width:var(--nb-shell-w);margin:0 auto;padding-inline:clamp(12px,3vw,24px);}
 


### PR DESCRIPTION
## Summary
- remove the forced 100vh minimum height on the Surge Signature quiz container so it can size to its content
- add an explicit auto min-height override for the quiz variant while keeping shared styling with the result view

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d1112f0c788331a3148d456d93a76b