### PR TITLE
Set quiz surge signature background to white

### DIFF
--- a/assets/nb-quiz-surgesignature.css
+++ b/assets/nb-quiz-surgesignature.css
@@ -28,7 +28,7 @@
 .nb-quiz.nb-quiz--surgesignature,
 .nb-result--surgesignature{
   position:relative;
-  background:var(--nb-pebble, #f5f6f4);
+  background:#fff;
   background-repeat:no-repeat;
 }
 


### PR DESCRIPTION
## Summary
- set the Surge Signature quiz wrapper background color to white

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d11221390c83319dd00b3a3083d211