### PR TITLE
Quiz → Shopify tags (retry after Mailchimp)

### DIFF
--- a/sections/nb-quiz-surgesignature.liquid
+++ b/sections/nb-quiz-surgesignature.liquid
@@ -44,7 +44,7 @@
       <input type="text" name="contact[first_name]" id="nb-sf-fname">
       <input type="text" name="contact[last_name]" id="nb-sf-lname">
       <input type="tel" name="contact[phone]" id="nb-sf-phone">
-      <!-- newsletter tag ensures “Email subscription: Subscribed” -->
+      <input type="hidden" name="contact[accepts_marketing]" value="true">
       <input type="hidden" name="contact[tags]" id="nb-sf-tags" value="newsletter">
     {% endform %}
   </div>


### PR DESCRIPTION
- Keeps Mailchimp capture.
- Submits Shopify newsletter form immediately and again after 2.5s (and 6s) to append tags reliably.
- Adds accepts_marketing + tag string including Style; no UI change.

------
https://chatgpt.com/codex/tasks/task_e_68d14d99dbd08331af379c22762f49f2