### PR TITLE
Reword Shopify payload comment to avoid Liquid parsing

### DIFF
--- a/snippets/nb-shopify-tag-worker.liquid
+++ b/snippets/nb-shopify-tag-worker.liquid
@@ -23,7 +23,7 @@
   }
 
   async function postToShopify(job){
-    // Build the same payload Shopify’s {% form 'customer' %} would send
+    // Build the same payload Shopify’s customer form would send
     var fd = new FormData();
     fd.set('form_type', 'customer');
     fd.set('utf8', '✓');


### PR DESCRIPTION
## Summary
- reword Shopify form payload comment to avoid Liquid from parsing a form tag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d153174b2c83318bffe311bad90cd1