### PR TITLE
Improve Shopify contact posting reliability

### DIFF
--- a/assets/nb-contact-dualpost.js
+++ b/assets/nb-contact-dualpost.js
@@ -29,9 +29,21 @@
     if (hasConsent) { fd.set('contact[accepts_marketing]', 'true'); tags.unshift('newsletter'); }
     fd.set('contact[tags]', tags.join(', '));
 
-    fetch('/contact#contact_form', { method: 'POST', body: fd, credentials: 'same-origin' }).catch(()=>{});
+    const url = '/contact#contact_form';
+    const beaconSent = typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function'
+      ? navigator.sendBeacon(url, fd)
+      : false;
+
+    if (!beaconSent) {
+      fetch(url, {
+        method: 'POST',
+        body: fd,
+        credentials: 'same-origin',
+        keepalive: true
+      }).catch(()=>{});
+    }
   }
 
   // Hook the Mailchimp submit; fire Shopify in parallel (non-blocking)
-  mc.addEventListener('submit', function(){ setTimeout(postShopify, 0); }, { capture: true });
+  mc.addEventListener('submit', function(){ postShopify(); }, { capture: true });
 })();


### PR DESCRIPTION
## Summary
- call the Shopify contact post directly during the Mailchimp submit flow
- send the Shopify payload with `navigator.sendBeacon` when available and fall back to a keepalive `fetch`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d15e5bc2508331af509daeec75b8fa