### PR TITLE
Set marketing consent on quiz Shopify submission

### DIFF
--- a/assets/nb-quiz-surgesignature.js
+++ b/assets/nb-quiz-surgesignature.js
@@ -207,6 +207,7 @@
               const fL = document.getElementById('nb-sf-lname');
               const fP = document.getElementById('nb-sf-phone');
               const fTags = document.getElementById('nb-sf-tags');
+              const fAccepts = document.getElementById('nb-sf-accepts');
               if (!sf || !fEmail || !fTags) return;
 
               const email = sub.querySelector('[name="EMAIL"]')?.value || '';
@@ -219,6 +220,7 @@
               if (fF) fF.value = fname;
               if (fL) fL.value = lname;
               if (fP) fP.value = phone;
+              if (fAccepts) fAccepts.value = 'true';
 
               // Tag set (newsletter only if consent checked — we control by gating the call)
               const tags = [

--- a/sections/nb-quiz-surgesignature.liquid
+++ b/sections/nb-quiz-surgesignature.liquid
@@ -45,6 +45,7 @@
       <input type="text" name="contact[last_name]" id="nb-sf-lname">
       <input type="tel" name="contact[phone]" id="nb-sf-phone">
       <input type="hidden" name="contact[tags]" id="nb-sf-tags" value="">
+      <input type="hidden" name="contact[accepts_marketing]" id="nb-sf-accepts" value="false">
       <!-- accepts_marketing will be implied by submitting only when consent is checked -->
     {% endform %}
   </div>


### PR DESCRIPTION
## Summary
- add a hidden accepts_marketing input to the Shopify customer form
- ensure quiz submissions flag marketing consent before the form submits

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d1601f02f08331874c6552b519911d