### PR TITLE
Improve Shopify contact keepalive submissions

### DIFF
--- a/assets/nb-contact-dualpost.js
+++ b/assets/nb-contact-dualpost.js
@@ -6,6 +6,48 @@
 
   function val(sel){ const el = mc.querySelector(sel); return el ? (el.value || '').trim() : ''; }
 
+  function nbPostShopifyCustomerFallback(payload){
+    try{
+      const body = new URLSearchParams();
+      const url = '/contact#contact_form';
+      const contentType = 'application/x-www-form-urlencoded;charset=UTF-8';
+      const headers = { 'Content-Type': contentType };
+
+      body.set('form_type','customer');
+      body.set('utf8','✓');
+      body.set('contact[email]', payload.email || '');
+      if (payload.fname) body.set('contact[first_name]', payload.fname);
+      if (payload.lname) body.set('contact[last_name]', payload.lname);
+      if (payload.phone) body.set('contact[phone]', payload.phone);
+
+      const tags = [];
+      if (payload.consent) { body.set('contact[accepts_marketing]','true'); tags.push('newsletter'); }
+      if (Array.isArray(payload.tags) && payload.tags.length) {
+        tags.push.apply(tags, payload.tags);
+      }
+      body.set('contact[tags]', tags.join(', '));
+
+      const encoded = body.toString();
+      if (navigator.sendBeacon) {
+        const blob = new Blob([encoded], { type: contentType });
+        navigator.sendBeacon(url, blob);
+        return Promise.resolve();
+      }
+
+      return fetch(url, {
+        method:'POST',
+        body: encoded,
+        credentials:'same-origin',
+        keepalive: true,
+        headers
+      });
+    }catch(e){ /* noop */ }
+  }
+
+  const postCustomer = typeof window.nbPostShopifyCustomer === 'function'
+    ? window.nbPostShopifyCustomer
+    : nbPostShopifyCustomerFallback;
+
   function postShopify(){
     const email = val('[name="EMAIL"], input[type="email"]');
     if (!email) return;
@@ -15,21 +57,9 @@
     const phone = val('[name="PHONE"], [type="tel"], [name="phone"]');
     const consent = !!mc.querySelector('input[name="gdpr[CONSENT]"]')?.checked;
 
-    const fd = new FormData();
-    fd.set('form_type','customer'); fd.set('utf8','✓');
-    fd.set('contact[email]', email);
-    if (fname) fd.set('contact[first_name]', fname);
-    if (lname) fd.set('contact[last_name]', lname);
-    if (phone) fd.set('contact[phone]', phone);
-
-    const tags = [];
-    if (consent){ fd.set('contact[accepts_marketing]','true'); tags.push('newsletter'); }
-    tags.push('Source: /contact');
-    fd.set('contact[tags]', tags.join(', '));
-
-    fetch('/contact#contact_form', { method:'POST', body: fd, credentials:'same-origin' }).catch(()=>{});
+    postCustomer({ email, fname, lname, phone, consent, tags: ['Source: /contact'] });
   }
 
   // Hook Mailchimp submit; send Shopify in parallel (non-blocking)
-  mc.addEventListener('submit', function(){ setTimeout(postShopify, 0); }, { capture:true });
+  mc.addEventListener('submit', function(){ postShopify(); }, { capture:true });
 })();


### PR DESCRIPTION
## Summary
- ensure the Shopify customer post in the quiz uses a keepalive-compatible payload and exposes the helper globally
- update the contact form helper to reuse the keepalive logic and trigger before Mailchimp navigation

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d163f17ec08331856e312f95243b68