### PR TITLE
Ensure Shopify posts use beacon or keepalive fetch

### DIFF
--- a/assets/nb-contact-dualpost.js
+++ b/assets/nb-contact-dualpost.js
@@ -8,30 +8,28 @@
 
   function nbPostShopifyCustomerFallback(payload){
     try{
-      const body = new URLSearchParams();
+      const params = new URLSearchParams();
       const url = '/contact#contact_form';
       const contentType = 'application/x-www-form-urlencoded;charset=UTF-8';
-      const headers = { 'Content-Type': contentType };
 
-      body.set('form_type','customer');
-      body.set('utf8','✓');
-      body.set('contact[email]', payload.email || '');
-      if (payload.fname) body.set('contact[first_name]', payload.fname);
-      if (payload.lname) body.set('contact[last_name]', payload.lname);
-      if (payload.phone) body.set('contact[phone]', payload.phone);
+      params.set('form_type','customer');
+      params.set('utf8','✓');
+      params.set('contact[email]', payload.email || '');
+      if (payload.fname) params.set('contact[first_name]', payload.fname);
+      if (payload.lname) params.set('contact[last_name]', payload.lname);
+      if (payload.phone) params.set('contact[phone]', payload.phone);
 
       const tags = [];
-      if (payload.consent) { body.set('contact[accepts_marketing]','true'); tags.push('newsletter'); }
+      if (payload.consent) { params.set('contact[accepts_marketing]','true'); tags.push('newsletter'); }
       if (Array.isArray(payload.tags) && payload.tags.length) {
         tags.push.apply(tags, payload.tags);
       }
-      body.set('contact[tags]', tags.join(', '));
+      params.set('contact[tags]', tags.join(', '));
 
-      const encoded = body.toString();
+      const encoded = params.toString();
       if (navigator.sendBeacon) {
         const blob = new Blob([encoded], { type: contentType });
-        navigator.sendBeacon(url, blob);
-        return Promise.resolve();
+        if (navigator.sendBeacon(url, blob)) return Promise.resolve();
       }
 
       return fetch(url, {
@@ -39,7 +37,7 @@
         body: encoded,
         credentials:'same-origin',
         keepalive: true,
-        headers
+        headers: { 'Content-Type': contentType }
       });
     }catch(e){ /* noop */ }
   }

--- a/assets/nb-quiz-surgesignature.js
+++ b/assets/nb-quiz-surgesignature.js
@@ -3,21 +3,20 @@
 
   function nbPostShopifyCustomer(payload){
     try{
-      const body = new URLSearchParams();
+      const params = new URLSearchParams();
       const url = '/contact#contact_form';
       const contentType = 'application/x-www-form-urlencoded;charset=UTF-8';
-      const headers = { 'Content-Type': contentType };
       // Required fields for Shopify newsletter endpoint
-      body.set('form_type','customer');
-      body.set('utf8','✓');
-      body.set('contact[email]', payload.email || '');
-      if (payload.fname) body.set('contact[first_name]', payload.fname);
-      if (payload.lname) body.set('contact[last_name]', payload.lname);
-      if (payload.phone) body.set('contact[phone]', payload.phone);
+      params.set('form_type','customer');
+      params.set('utf8','✓');
+      params.set('contact[email]', payload.email || '');
+      if (payload.fname) params.set('contact[first_name]', payload.fname);
+      if (payload.lname) params.set('contact[last_name]', payload.lname);
+      if (payload.phone) params.set('contact[phone]', payload.phone);
 
       // Consent + tags
       const tags = [];
-      if (payload.consent) { body.set('contact[accepts_marketing]','true'); tags.push('newsletter'); }
+      if (payload.consent) { params.set('contact[accepts_marketing]','true'); tags.push('newsletter'); }
       if (Array.isArray(payload.tags) && payload.tags.length) {
         tags.push.apply(tags, payload.tags);
       } else {
@@ -25,13 +24,12 @@
         if (payload.styleLabel) tags.push('Style: ' + payload.styleLabel);
         tags.push('Source: /surge-signature');
       }
-      body.set('contact[tags]', tags.join(', '));
+      params.set('contact[tags]', tags.join(', '));
 
-      const encoded = body.toString();
+      const encoded = params.toString();
       if (navigator.sendBeacon) {
         const blob = new Blob([encoded], { type: contentType });
-        navigator.sendBeacon(url, blob);
-        return Promise.resolve();
+        if (navigator.sendBeacon(url, blob)) return Promise.resolve();
       }
 
       return fetch(url, {
@@ -39,7 +37,7 @@
         body: encoded,
         credentials:'same-origin',
         keepalive: true,
-        headers
+        headers: { 'Content-Type': contentType }
       });
     }catch(e){ /* swallow */ }
   }


### PR DESCRIPTION
## Summary
- ensure the contact form's Shopify submission builds a URL-encoded body and uses sendBeacon or keepalive fetch
- align the Surge Signature quiz Shopify submission helper with the same reliable transport so submissions survive page unloads

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d169e72618833190f12359dffd377d