### PR TITLE
Ensure Shopify contact consent matches Mailchimp opt-in

### DIFF
--- a/assets/nb-contact-dualpost.js
+++ b/assets/nb-contact-dualpost.js
@@ -53,7 +53,9 @@
     const fname = val('[name="FNAME"], [name="first_name"]');
     const lname = val('[name="LNAME"], [name="last_name"]');
     const phone = val('[name="PHONE"], [type="tel"], [name="phone"]');
-    const consent = !!mc.querySelector('input[name="gdpr[CONSENT]"]')?.checked;
+    const gdprConsent = !!mc.querySelector('input[name="gdpr[CONSENT]"]')?.checked;
+    const formConsent = !!document.querySelector('#JoinEmails')?.checked;
+    const consent = gdprConsent || formConsent;
 
     postCustomer({ email, fname, lname, phone, consent, tags: ['Source: /contact'] });
   }


### PR DESCRIPTION
## Summary
- include the contact form's JoinEmails checkbox when determining Shopify consent
- pass the combined consent flag through to the Shopify customer payload so marketing opt-ins are recorded

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d16e31babc83318b635c3f8e740cd3