### PR TITLE
Refine contact helper for Shopify submissions

### DIFF
--- a/assets/nb-contact-dualpost.js
+++ b/assets/nb-contact-dualpost.js
@@ -6,60 +6,62 @@
 
   function val(sel){ const el = mc.querySelector(sel); return el ? (el.value || '').trim() : ''; }
 
-  function nbPostShopifyCustomerFallback(payload){
-    try{
-      const params = new URLSearchParams();
+  function nbSubmitShopifyContactFallback(payload){
+    try {
       const url = '/contact#contact_form';
-      const contentType = 'application/x-www-form-urlencoded;charset=UTF-8';
-
-      params.set('form_type','customer');
-      params.set('utf8','✓');
+      const params = new URLSearchParams();
+      params.set('form_type', 'contact');
+      params.set('utf8', '✓');
       params.set('contact[email]', payload.email || '');
-      if (payload.fname) params.set('contact[first_name]', payload.fname);
-      if (payload.lname) params.set('contact[last_name]', payload.lname);
-      if (payload.phone) params.set('contact[phone]', payload.phone);
+      params.set('contact[first_name]', payload.firstName || '');
+      params.set('contact[last_name]', payload.lastName || '');
+      params.set('contact[phone]', payload.phone || '');
+      params.set('contact[name]', [payload.firstName, payload.lastName].filter(Boolean).join(' '));
 
-      const tags = [];
-      if (payload.consent) { params.set('contact[accepts_marketing]','true'); tags.push('newsletter'); }
-      if (Array.isArray(payload.tags) && payload.tags.length) {
-        tags.push.apply(tags, payload.tags);
+      const tags = Array.isArray(payload.tags) ? payload.tags.slice() : [];
+      if (payload.acceptsMarketing && !tags.some(tag => String(tag).toLowerCase() === 'newsletter')) {
+        tags.unshift('newsletter');
       }
       params.set('contact[tags]', tags.join(', '));
+      params.set('accepts_marketing', payload.acceptsMarketing ? 'true' : 'false');
 
       const encoded = params.toString();
-      if (navigator.sendBeacon) {
-        const blob = new Blob([encoded], { type: contentType });
-        if (navigator.sendBeacon(url, blob)) return Promise.resolve();
-      }
-
       return fetch(url, {
-        method:'POST',
+        method: 'POST',
         body: encoded,
-        credentials:'same-origin',
+        credentials: 'same-origin',
         keepalive: true,
-        headers: { 'Content-Type': contentType }
-      });
-    }catch(e){ /* noop */ }
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8' }
+      }).catch(() => {});
+    } catch(_) {
+      return Promise.resolve();
+    }
   }
 
-  const postCustomer = typeof window.nbPostShopifyCustomer === 'function'
-    ? window.nbPostShopifyCustomer
-    : nbPostShopifyCustomerFallback;
+  const submitContact = typeof window.nbSubmitShopifyContact === 'function'
+    ? window.nbSubmitShopifyContact
+    : nbSubmitShopifyContactFallback;
 
   function postShopify(){
     const email = val('[name="EMAIL"], input[type="email"]');
     if (!email) return;
 
-    const fname = val('[name="FNAME"], [name="first_name"]');
-    const lname = val('[name="LNAME"], [name="last_name"]');
+    const firstName = val('[name="FNAME"], [name="first_name"]');
+    const lastName = val('[name="LNAME"], [name="last_name"]');
     const phone = val('[name="PHONE"], [type="tel"], [name="phone"]');
     const gdprConsent = !!mc.querySelector('input[name="gdpr[CONSENT]"]')?.checked;
     const formConsent = !!document.querySelector('#JoinEmails')?.checked;
-    const consent = gdprConsent || formConsent;
+    const acceptsMarketing = gdprConsent || formConsent;
 
-    postCustomer({ email, fname, lname, phone, consent, tags: ['Source: /contact'] });
+    submitContact({
+      email,
+      firstName,
+      lastName,
+      phone,
+      tags: ['Source: /contact'],
+      acceptsMarketing
+    });
   }
 
-  // Hook Mailchimp submit; send Shopify in parallel (non-blocking)
   mc.addEventListener('submit', function(){ postShopify(); }, { capture:true });
 })();

--- a/sections/nibana-contact.liquid
+++ b/sections/nibana-contact.liquid
@@ -210,11 +210,16 @@
 {%- endcomment -%}
 {% if section.settings.use_shopify_customer_flow %}
   <div aria-hidden="true" style="position:absolute; width:1px; height:1px; overflow:hidden; left:-9999px;">
-    <iframe id="NewsletterFrame" name="NewsletterFrame" tabindex="-1"></iframe>
-    {% form 'customer', id: 'NibanaHiddenNewsletter' %}
-      <input type="email" name="contact[email]" id="HiddenCustomerEmail">
-      <input type="hidden" name="contact[tags]" id="HiddenCustomerTags" value="newsletter, Contact Form">
-      <button id="HiddenSubmit" type="submit">Submit</button>
+    <iframe id="HiddenContactFrame" name="HiddenContactFrame" tabindex="-1"></iframe>
+    {% form 'contact', id: 'NibanaHiddenContact', target: 'HiddenContactFrame' %}
+      <input type="email"   name="contact[email]"          id="HiddenContactEmail">
+      <input type="text"    name="contact[name]"           id="HiddenContactName">
+      <input type="text"    name="contact[first_name]"     id="HiddenContactFirstName">
+      <input type="text"    name="contact[last_name]"      id="HiddenContactLastName">
+      <input type="tel"     name="contact[phone]"          id="HiddenContactPhone">
+      <input type="hidden"  name="contact[tags]"           id="HiddenContactTags" value="">
+      <input type="hidden"  name="accepts_marketing"       id="HiddenContactAcceptsMarketing" value="false">
+      <button id="HiddenContactSubmit" type="submit">Submit</button>
     {% endform %}
   </div>
 {% endif %}


### PR DESCRIPTION
## Summary
- convert the hidden Shopify helper into a contact form with iframe-only submission fields
- expose nbSubmitShopifyContact to populate the helper, mirror Shopify submission logic, and emit debug updates
- point the dual-post script at the shared helper while keeping a minimal fetch fallback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d172b54f14833192e4de464812f108