### PR TITLE
Ensure Surge Signature quiz uses Shopify contact helper

### DIFF
--- a/sections/nb-quiz-surgesignature.liquid
+++ b/sections/nb-quiz-surgesignature.liquid
@@ -24,6 +24,7 @@
   </div>
 
   <script src="{{ 'nb-quiz-surgesignature.js' | asset_url }}" defer></script>
+  <script src="{{ 'nb-contact.js' | asset_url }}" defer></script>
   <link rel="stylesheet" href="{{ 'nb-quiz-surgesignature.css' | asset_url }}" media="all">
   <script>
     window.NB_QUIZ = window.NB_QUIZ || {};


### PR DESCRIPTION
## Summary
- replace the quiz-specific Shopify customer poster with the shared nbSubmitShopifyContact helper and provide a lightweight fallback
- load the Shopify contact helper on quiz pages and inject the hidden contact form markup when it is missing so the helper can submit successfully
- tag quiz submissions with Surge Signature specific metadata before invoking the helper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d175da2d748331bd85ba4ce011e5ab