### PR TITLE
Add captcha-aware Shopify contact overlay

### DIFF
--- a/assets/nb-contact-dualpost.js
+++ b/assets/nb-contact-dualpost.js
@@ -38,7 +38,7 @@
     }
   }
 
-  function postShopify(){
+  async function postShopify(){
     const email = val('[name="EMAIL"], input[type="email"]');
     if (!email) return;
 
@@ -59,8 +59,13 @@
     };
 
     const hiddenForm = document.getElementById('NibanaHiddenNewsletter') || document.getElementById('NibanaHiddenContact');
-    if (typeof window.nbSubmitShopifyContact === 'function' && hiddenForm) {
-      window.nbSubmitShopifyContact(payload);
+    const helperFrame = document.getElementById('HiddenNewsletterFrame') || document.getElementById('HiddenContactFrame');
+    const hasHelper = typeof window.nbSubmitShopifyContact === 'function' && hiddenForm && helperFrame;
+
+    if (hasHelper) {
+      try {
+        await window.nbSubmitShopifyContact(payload);
+      } catch(_) {}
     } else {
       postEncodedShopifyContact(payload);
     }

--- a/assets/nb-contact.js
+++ b/assets/nb-contact.js
@@ -26,85 +26,229 @@
     }
   }
 
-  function nbSubmitShopifyContact({ email = '', fname = '', lname = '', phone = '', consent = false, tags = [] } = {}){
+  function analyseShopifyFrame(frame){
+    let doc = null;
     try {
-      const hiddenForm = document.getElementById('NibanaHiddenNewsletter') || document.getElementById('NibanaHiddenContact');
-      if (!hiddenForm) {
-        show('Hidden Shopify form missing');
-        return false;
-      }
-
-      const usingCustomerForm = hiddenForm.id === 'NibanaHiddenNewsletter';
-      ensureTarget(hiddenForm, usingCustomerForm ? 'HiddenNewsletterFrame' : 'HiddenContactFrame');
-
-      const trimmedEmail = (email || '').trim();
-      const firstName = (fname || '').trim();
-      const lastName = (lname || '').trim();
-      const trimmedPhone = (phone || '').trim();
-      const acceptsMarketing = !!consent;
-      const fullName = [firstName, lastName].filter(Boolean).join(' ').trim();
-      const marketingValue = acceptsMarketing ? 'true' : 'false';
-      const tagList = normaliseTags(tags, acceptsMarketing);
-      const tagString = tagList.join(', ');
-
-      assignValue(['HiddenCustomerEmail', 'HiddenContactEmail'], trimmedEmail);
-      assignValue(['HiddenCustomerFirstName', 'HiddenContactFirstName'], firstName);
-      assignValue(['HiddenCustomerLastName', 'HiddenContactLastName'], lastName);
-      assignValue(['HiddenCustomerPhone', 'HiddenContactPhone'], trimmedPhone);
-      assignValue(['HiddenCustomerTags', 'HiddenContactTags'], tagString);
-      assignValue(['HiddenCustomerAcceptsMarketing', 'HiddenContactAcceptsMarketing'], marketingValue);
-      assignValue(['HiddenCustomerName', 'HiddenContactName'], fullName);
-
-      const fd = new FormData(hiddenForm);
-      fd.set('contact[email]', trimmedEmail);
-      fd.set('contact[first_name]', firstName);
-      fd.set('contact[last_name]', lastName);
-      fd.set('contact[phone]', trimmedPhone);
-      fd.set('contact[tags]', tagString);
-      fd.set('contact[name]', fullName);
-      fd.set('contact[accepts_marketing]', marketingValue);
-      if (usingCustomerForm) {
-        fd.set('customer[email]', trimmedEmail);
-        fd.set('customer[first_name]', firstName);
-        fd.set('customer[last_name]', lastName);
-        fd.set('customer[phone]', trimmedPhone);
-        fd.set('customer[tags]', tagString);
-        fd.set('customer[accepts_marketing]', marketingValue);
-      } else {
-        fd.set('accepts_marketing', marketingValue);
-      }
-
-      const url = hiddenForm.getAttribute('action') || '/contact#contact_form';
-
-      try {
-        if (typeof navigator.sendBeacon === 'function') {
-          const params = new URLSearchParams();
-          for (const [key, value] of fd.entries()) {
-            params.append(key, value);
-          }
-          const encoded = params.toString();
-          const blob = new Blob([encoded], { type: 'application/x-www-form-urlencoded;charset=UTF-8' });
-          if (navigator.sendBeacon(url, blob)) {
-            show('Shopify beacon sent');
-          }
-        }
-      } catch(_) {}
-
-      try {
-        fetch(url, { method: 'POST', body: fd, credentials: 'same-origin', keepalive: true })
-          .then(() => show('Shopify fetch keepalive complete'))
-          .catch(() => {});
-      } catch(_) {}
-
-      try {
-        hiddenForm.requestSubmit ? hiddenForm.requestSubmit() : hiddenForm.submit();
-        show('Shopify iframe submit fired');
-      } catch(_) {}
-
-      return true;
+      doc = frame?.contentDocument || frame?.contentWindow?.document || null;
     } catch(_) {
-      return false;
+      return { state: 'unreachable', doc: null };
     }
+    if (!doc || !doc.body) return { state: 'empty', doc };
+
+    const captchaSelectors = '.shopify-challenge__container, form[action*="/challenge"], #g-recaptcha, .g-recaptcha, .h-captcha, iframe[src*="captcha"], [data-shopify="captcha"], [name="g-recaptcha-response"], [name="h-captcha-response"]';
+    if (doc.querySelector(captchaSelectors)) return { state: 'captcha', doc };
+
+    const successSelectors = '.form-status--success, .note--success, .alert--success, [data-form-status="success"], [data-success-message], #ContactSuccess, #CustomerSuccess';
+    if (doc.querySelector(successSelectors)) return { state: 'success', doc };
+
+    const errorSelectors = '.form-status--error, .note--error, .alert--error, .errors, [data-form-status="error"], .form__message--error';
+    if (doc.querySelector(errorSelectors)) return { state: 'error', doc };
+
+    const bodyText = (doc.body.textContent || '').toLowerCase();
+    if (bodyText.includes('thank you for contacting') || bodyText.includes('thanks for contacting') || bodyText.includes('we\'ll be in touch soon')) {
+      return { state: 'success', doc };
+    }
+    if ((bodyText.includes('captcha') || bodyText.includes('are you human')) && doc.querySelector('form')) {
+      return { state: 'captcha', doc };
+    }
+    if (bodyText.includes('error') && (bodyText.includes('contact') || bodyText.includes('message'))) {
+      return { state: 'error', doc };
+    }
+    return { state: 'unknown', doc };
+  }
+
+  function nbSubmitShopifyContact({ email = '', fname = '', lname = '', phone = '', consent = false, tags = [] } = {}){
+    return new Promise(function(resolve, reject){
+      let settled = false;
+      let submitted = false;
+      let overlayVisible = false;
+      let previousActive = null;
+      let frameLoadTimer = null;
+
+      function finish(ok, payload){
+        if (settled) return;
+        settled = true;
+        if (frameLoadTimer) clearTimeout(frameLoadTimer);
+        cleanup();
+        if (ok) {
+          show('Shopify contact helper resolved');
+          resolve(payload);
+        } else {
+          const err = payload instanceof Error ? payload : new Error(String(payload || 'Shopify contact failed'));
+          show('Shopify contact helper failed: ' + (err && err.message ? err.message : 'unknown'));
+          reject(err);
+        }
+      }
+
+      function cleanup(){
+        try { iframe && iframe.removeEventListener('load', onFrameLoad); } catch(_) {}
+        closeControls.forEach(function(btn){ btn.removeEventListener('click', onOverlayClose); });
+        document.removeEventListener('keydown', onEscape);
+        hideOverlay();
+      }
+
+      function showOverlay(){
+        if (!overlay || overlayVisible) return;
+        previousActive = document.activeElement;
+        overlay.removeAttribute('hidden');
+        overlay.setAttribute('aria-hidden', 'false');
+        overlayVisible = true;
+        const focusEl = overlay.querySelector('[data-nb-captcha-focus]') || overlay.querySelector('[data-nb-captcha-close]') || overlay.querySelector('iframe');
+        if (focusEl && typeof focusEl.focus === 'function') {
+          requestAnimationFrame(function(){ focusEl.focus(); });
+        }
+      }
+
+      function hideOverlay(){
+        if (!overlay || !overlayVisible) return;
+        overlay.setAttribute('aria-hidden', 'true');
+        overlay.setAttribute('hidden', '');
+        overlayVisible = false;
+        const focusEl = previousActive;
+        previousActive = null;
+        if (focusEl && typeof focusEl.focus === 'function') {
+          requestAnimationFrame(function(){ focusEl.focus(); });
+        }
+      }
+
+      function onOverlayClose(event){
+        if (event) event.preventDefault();
+        finish(false, new Error('Shopify contact cancelled'));
+      }
+
+      function onEscape(event){
+        if (event.key === 'Escape' && overlayVisible) {
+          event.preventDefault();
+          finish(false, new Error('Shopify contact cancelled'));
+        }
+      }
+
+      function onFrameLoad(){
+        if (!submitted || !iframe) return;
+        const analysis = analyseShopifyFrame(iframe);
+        show('Shopify frame load: ' + analysis.state);
+        if (analysis.state === 'captcha') {
+          showOverlay();
+          return;
+        }
+        if (analysis.state === 'success') {
+          finish(true, { status: 'success' });
+          return;
+        }
+        if (analysis.state === 'error') {
+          finish(false, new Error('Shopify contact failed'));
+        }
+      }
+
+      let hiddenForm;
+      let iframe;
+      let overlay;
+      let closeControls = [];
+      try {
+        hiddenForm = document.getElementById('NibanaHiddenNewsletter') || document.getElementById('NibanaHiddenContact');
+        if (!hiddenForm) {
+          show('Hidden Shopify form missing');
+          finish(false, new Error('Hidden Shopify form missing'));
+          return;
+        }
+
+        const usingCustomerForm = hiddenForm.id === 'NibanaHiddenNewsletter';
+        ensureTarget(hiddenForm, usingCustomerForm ? 'HiddenNewsletterFrame' : 'HiddenContactFrame');
+
+        const targetName = hiddenForm.getAttribute('target');
+        const frames = Array.prototype.slice.call(document.querySelectorAll('iframe'));
+        iframe = frames.find(function(el){ return el.getAttribute('name') === targetName; })
+              || (usingCustomerForm ? document.getElementById('HiddenNewsletterFrame') : document.getElementById('HiddenContactFrame'))
+              || null;
+        if (!iframe) {
+          show('Hidden Shopify frame missing');
+          finish(false, new Error('Hidden Shopify frame missing'));
+          return;
+        }
+
+        overlay = document.querySelector('[data-nb-captcha-overlay]');
+        closeControls = overlay ? Array.prototype.slice.call(overlay.querySelectorAll('[data-nb-captcha-close]')) : [];
+
+        iframe.addEventListener('load', onFrameLoad);
+        closeControls.forEach(function(btn){ btn.addEventListener('click', onOverlayClose); });
+        document.addEventListener('keydown', onEscape);
+
+        const trimmedEmail = (email || '').trim();
+        const firstName = (fname || '').trim();
+        const lastName = (lname || '').trim();
+        const trimmedPhone = (phone || '').trim();
+        const acceptsMarketing = !!consent;
+        const fullName = [firstName, lastName].filter(Boolean).join(' ').trim();
+        const marketingValue = acceptsMarketing ? 'true' : 'false';
+        const tagList = normaliseTags(tags, acceptsMarketing);
+        const tagString = tagList.join(', ');
+
+        assignValue(['HiddenCustomerEmail', 'HiddenContactEmail'], trimmedEmail);
+        assignValue(['HiddenCustomerFirstName', 'HiddenContactFirstName'], firstName);
+        assignValue(['HiddenCustomerLastName', 'HiddenContactLastName'], lastName);
+        assignValue(['HiddenCustomerPhone', 'HiddenContactPhone'], trimmedPhone);
+        assignValue(['HiddenCustomerTags', 'HiddenContactTags'], tagString);
+        assignValue(['HiddenCustomerAcceptsMarketing', 'HiddenContactAcceptsMarketing'], marketingValue);
+        assignValue(['HiddenCustomerName', 'HiddenContactName'], fullName);
+
+        const fd = new FormData(hiddenForm);
+        fd.set('contact[email]', trimmedEmail);
+        fd.set('contact[first_name]', firstName);
+        fd.set('contact[last_name]', lastName);
+        fd.set('contact[phone]', trimmedPhone);
+        fd.set('contact[tags]', tagString);
+        fd.set('contact[name]', fullName);
+        fd.set('contact[accepts_marketing]', marketingValue);
+        if (usingCustomerForm) {
+          fd.set('customer[email]', trimmedEmail);
+          fd.set('customer[first_name]', firstName);
+          fd.set('customer[last_name]', lastName);
+          fd.set('customer[phone]', trimmedPhone);
+          fd.set('customer[tags]', tagString);
+          fd.set('customer[accepts_marketing]', marketingValue);
+        } else {
+          fd.set('accepts_marketing', marketingValue);
+        }
+
+        const url = hiddenForm.getAttribute('action') || '/contact#contact_form';
+
+        try {
+          if (typeof navigator.sendBeacon === 'function') {
+            const params = new URLSearchParams();
+            fd.forEach(function(value, key){ params.append(key, value); });
+            const encoded = params.toString();
+            const blob = new Blob([encoded], { type: 'application/x-www-form-urlencoded;charset=UTF-8' });
+            if (navigator.sendBeacon(url, blob)) {
+              show('Shopify beacon sent');
+            }
+          }
+        } catch(_) {}
+
+        try {
+          fetch(url, { method: 'POST', body: fd, credentials: 'same-origin', keepalive: true })
+            .then(function(){ show('Shopify fetch keepalive complete'); })
+            .catch(function(){});
+        } catch(_) {}
+
+        try {
+          hiddenForm.requestSubmit ? hiddenForm.requestSubmit() : hiddenForm.submit();
+          submitted = true;
+          show('Shopify iframe submit fired');
+        } catch(err) {
+          finish(false, err);
+          return;
+        }
+
+        frameLoadTimer = setTimeout(function(){
+          if (!settled) {
+            show('Shopify contact timeout');
+            finish(false, new Error('Shopify contact timeout'));
+          }
+        }, 25000);
+      } catch(error) {
+        finish(false, error);
+      }
+    });
   }
 
   window.nbSubmitShopifyContact = nbSubmitShopifyContact;
@@ -134,7 +278,7 @@
     };
     show('ready');
 
-    document.addEventListener('submit', function(e){
+    document.addEventListener('submit', async function(e){
       const form = e.target;
       if (!form || form.id !== 'NibanaContactForm') return;
 
@@ -154,15 +298,16 @@
 
       if (scEnabled) {
         if (typeof window.nbSubmitShopifyContact === 'function') {
-          const ok = window.nbSubmitShopifyContact({
-            email,
-            fname: firstName,
-            lname: lastName,
-            phone,
-            tags,
-            consent: !!join.checked
-          });
-          if (!ok) show('Shopify contact helper failed');
+          try {
+            await window.nbSubmitShopifyContact({
+              email,
+              fname: firstName,
+              lname: lastName,
+              phone,
+              tags,
+              consent: !!join.checked
+            });
+          } catch(_) {}
         } else {
           show('Shopify contact helper missing');
         }

--- a/assets/nb-quiz-surgesignature.js
+++ b/assets/nb-quiz-surgesignature.js
@@ -303,7 +303,7 @@
           const form = resultEl.querySelector('[data-nb-quiz-sub]');
           if(!form) return;
 
-          form.addEventListener('submit', function(){
+          form.addEventListener('submit', async function(){
             const email = form.querySelector('[name="EMAIL"]')?.value || '';
             const firstName = (form.querySelector('[name="FNAME"]')?.value || '').trim();
             const lastName = (form.querySelector('[name="LNAME"]')?.value || '').trim();
@@ -327,23 +327,28 @@
             };
 
             const hiddenForm = populateHiddenShopifyForm(payload);
+            const helperHiddenForm = document.getElementById('NibanaHiddenNewsletter') || document.getElementById('NibanaHiddenContact');
+            const helperFrame = document.getElementById('HiddenNewsletterFrame') || document.getElementById('HiddenContactFrame');
+            const helperAvailable = typeof window.nbSubmitShopifyContact === 'function' && helperHiddenForm && helperFrame;
+
             let submitted = false;
-            if (typeof window.nbSubmitShopifyContact === 'function') {
+            if (helperAvailable) {
               try {
-                submitted = window.nbSubmitShopifyContact({
+                await window.nbSubmitShopifyContact({
                   email: payload.email,
                   fname: payload.firstName,
                   lname: payload.lastName,
                   phone: payload.phone,
                   tags: payload.tags,
                   consent: payload.acceptsMarketing
-                }) === true;
+                });
+                submitted = true;
               } catch(_) {
                 submitted = false;
               }
             }
 
-            if (!submitted && hiddenForm) {
+            if (!helperAvailable && hiddenForm && !submitted) {
               try {
                 hiddenForm.requestSubmit ? hiddenForm.requestSubmit() : hiddenForm.submit();
                 submitted = true;
@@ -352,7 +357,7 @@
               }
             }
 
-            if (!submitted) {
+            if (!helperAvailable && !submitted) {
               fallbackShopifyContact(payload);
             }
           }, { capture:true });

--- a/sections/nibana-contact.liquid
+++ b/sections/nibana-contact.liquid
@@ -36,7 +36,7 @@
         align-items: start;
       }
     }
-    #{{ secid }} .nib-card {
+    #{{ secid }} .nib-card { 
   background: {{ section.settings.card_bg }};
   border: 1px solid {{ section.settings.card_border }};
   border-radius: {{ section.settings.card_radius }};
@@ -64,6 +64,107 @@
   box-shadow: 0 14px 36px rgba(0,0,0,.14);
   transition: box-shadow .2s ease, transform .12s ease;
 }
+
+    #{{ secid }} [data-nb-captcha-overlay] {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: clamp(16px, 5vw, 40px);
+      background: rgba(15, 23, 42, 0.55);
+      z-index: 9999;
+    }
+    #{{ secid }} [data-nb-captcha-overlay][hidden] {
+      display: none !important;
+    }
+    #{{ secid }} .nb-captcha-overlay__dialog {
+      position: relative;
+      z-index: 1;
+      background: #ffffff;
+      color: #0f172a;
+      width: min(640px, 100%);
+      border-radius: 20px;
+      box-shadow: 0 28px 64px rgba(15, 23, 42, 0.24);
+      padding: clamp(20px, 4vw, 32px);
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+    #{{ secid }} .nb-captcha-overlay__backdrop {
+      position: absolute;
+      inset: 0;
+      background: transparent;
+    }
+    #{{ secid }} .nb-captcha-overlay__header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 12px;
+    }
+    #{{ secid }} .nb-captcha-overlay__title {
+      margin: 0;
+      font-size: clamp(20px, 3vw, 26px);
+      line-height: 1.3;
+    }
+    #{{ secid }} .nb-captcha-overlay__icon-close {
+      background: none;
+      border: 0;
+      color: rgba(15, 23, 42, 0.55);
+      font-size: 28px;
+      line-height: 1;
+      padding: 4px;
+      cursor: pointer;
+    }
+    #{{ secid }} .nb-captcha-overlay__icon-close:hover,
+    #{{ secid }} .nb-captcha-overlay__icon-close:focus-visible {
+      color: rgba(15, 23, 42, 0.9);
+      outline: none;
+    }
+    #{{ secid }} .nb-captcha-overlay__copy {
+      margin: 0;
+      font-size: 15px;
+      line-height: 1.6;
+      color: rgba(15, 23, 42, 0.82);
+    }
+    #{{ secid }} .nb-captcha-overlay__frame {
+      border-radius: 16px;
+      border: 1px solid rgba(148, 163, 184, 0.6);
+      padding: 10px;
+      background: #f8fafc;
+    }
+    #{{ secid }} .nb-captcha-overlay__frame iframe {
+      width: 100%;
+      min-height: 420px;
+      border: 0;
+      border-radius: 12px;
+      background: #ffffff;
+    }
+    #{{ secid }} .nb-captcha-overlay__actions {
+      display: flex;
+      justify-content: flex-end;
+    }
+    #{{ secid }} .nb-captcha-overlay__close {
+      border: none;
+      background: none;
+      font: inherit;
+      color: #0f172a;
+      cursor: pointer;
+      padding: 8px 2px;
+    }
+    #{{ secid }} .nb-captcha-overlay__close:hover,
+    #{{ secid }} .nb-captcha-overlay__close:focus-visible {
+      text-decoration: underline;
+      outline: none;
+    }
+    #{{ secid }} .nb-captcha-overlay__form {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+    }
 
   </style>
 
@@ -204,23 +305,62 @@
         </div>
       {% endform %}
 
-      {%- comment -%}
-  Hidden customer/newsletter form (creates/updates Shopify Customer).
-  We also include a hidden iframe for a last-resort synchronous POST.
-{%- endcomment -%}
+  {%- comment -%}
+  Hidden customer/newsletter form (creates/updates Shopify Customer) and overlay
+  to surface Shopify's captcha when required.
+  {%- endcomment -%}
 {% if section.settings.use_shopify_customer_flow %}
-  <div aria-hidden="true" style="position:absolute; width:1px; height:1px; overflow:hidden; left:-9999px;">
-    <iframe id="HiddenNewsletterFrame" name="HiddenNewsletterFrame" tabindex="-1"></iframe>
-    {% form 'customer', id: 'NibanaHiddenNewsletter', target: 'HiddenNewsletterFrame' %}
-      <input type="email"   name="contact[email]"           id="HiddenCustomerEmail">
-      <input type="text"    name="contact[name]"            id="HiddenCustomerName">
-      <input type="text"    name="contact[first_name]"      id="HiddenCustomerFirstName">
-      <input type="text"    name="contact[last_name]"       id="HiddenCustomerLastName">
-      <input type="tel"     name="contact[phone]"           id="HiddenCustomerPhone">
-      <input type="hidden"  name="contact[tags]"            id="HiddenCustomerTags" value="">
-      <input type="hidden"  name="contact[accepts_marketing]" id="HiddenCustomerAcceptsMarketing" value="false">
-      <button id="HiddenCustomerSubmit" type="submit">Submit</button>
-    {% endform %}
+  <div
+    id="ShopifyCaptchaOverlay"
+    class="nb-captcha-overlay"
+    data-nb-captcha-overlay
+    hidden
+    aria-hidden="true"
+  >
+    <div class="nb-captcha-overlay__backdrop" data-nb-captcha-close></div>
+    <div
+      class="nb-captcha-overlay__dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="{{ secid }}-captcha-title"
+    >
+      <div class="nb-captcha-overlay__header">
+        <h2 id="{{ secid }}-captcha-title" class="nb-captcha-overlay__title" data-nb-captcha-focus tabindex="-1">
+          {{ section.settings.captcha_heading | default: 'Almost there…' }}
+        </h2>
+        <button type="button" class="nb-captcha-overlay__icon-close" data-nb-captcha-close aria-label="Close verification">
+          &times;
+        </button>
+      </div>
+      <p class="nb-captcha-overlay__copy">
+        {{ section.settings.captcha_copy | default: "Shopify sometimes asks for a quick captcha. Complete the prompt below to finish sending your message." }}
+      </p>
+      <div class="nb-captcha-overlay__frame" data-nb-captcha-frame>
+        <iframe
+          id="HiddenNewsletterFrame"
+          name="HiddenNewsletterFrame"
+          title="Shopify verification"
+          tabindex="0"
+        ></iframe>
+      </div>
+      <div class="nb-captcha-overlay__actions">
+        <button type="button" class="nb-captcha-overlay__close" data-nb-captcha-close>
+          {{ section.settings.captcha_close_label | default: 'Close' }}
+        </button>
+      </div>
+      <div class="nb-captcha-overlay__form" aria-hidden="true">
+        {% form 'customer', id: 'NibanaHiddenNewsletter', target: 'HiddenNewsletterFrame' %}
+          <input type="email"   name="contact[email]"           id="HiddenCustomerEmail">
+          <input type="text"    name="contact[name]"            id="HiddenCustomerName">
+          <input type="text"    name="contact[first_name]"      id="HiddenCustomerFirstName">
+          <input type="text"    name="contact[last_name]"       id="HiddenCustomerLastName">
+          <input type="tel"     name="contact[phone]"           id="HiddenCustomerPhone">
+          <input type="hidden"  name="contact[tags]"            id="HiddenCustomerTags" value="">
+          <input type="hidden"  name="contact[accepts_marketing]" id="HiddenCustomerAcceptsMarketing" value="false">
+          <button id="HiddenCustomerSubmit" type="submit">Submit</button>
+        {% endform %}
+      </div>
+    </div>
   </div>
 {% endif %}
     </div>
@@ -281,6 +421,10 @@
     { "type": "text", "id": "submit_label", "label": "Submit button label", "default": "Submit" },
     { "type": "text", "id": "success_text", "label": "Success message", "default": "Thanks for reaching out — we’ll get back within 1 business day." },
     { "type": "text", "id": "error_text", "label": "Error message", "default": "Please check the highlighted fields and try again." },
+
+    { "type": "text", "id": "captcha_heading", "label": "Captcha overlay heading", "default": "Almost there…" },
+    { "type": "textarea", "id": "captcha_copy", "label": "Captcha overlay copy", "default": "Shopify sometimes asks for a quick captcha. Complete the prompt below to finish sending your message." },
+    { "type": "text", "id": "captcha_close_label", "label": "Captcha overlay close label", "default": "Close" },
 
     { "type": "text", "id": "cta_submit_class", "label": "Submit button class (non-call CTA)", "default": "button" },
     { "type": "text", "id": "cta_call_class", "label": "Book-a-call button class (call CTA)", "default": "nb-cta" },


### PR DESCRIPTION
## Summary
- add a contact overlay so Shopify captcha challenges surface within the iframe
- refactor the Shopify contact helper to return a promise that drives the overlay and waits for success
- update dual-post and quiz flows to await the shared helper, falling back only when it is unavailable

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d1897ff57c8331a2455559bf79d819