### PR TITLE
Improve Shopify contact debugging

### DIFF
--- a/sections/nibana-contact.liquid
+++ b/sections/nibana-contact.liquid
@@ -432,7 +432,7 @@
     { "type": "text", "id": "subheading_class", "label": "Subheading class", "default": "paragraph" },
     { "type": "text", "id": "block_heading_class", "label": "Panel heading class", "default": "h3" },
 
-    { "type": "checkbox", "id": "enable_debug", "label": "Enable Mailchimp debug badge (temporary)", "default": false },
+    { "type": "checkbox", "id": "enable_debug", "label": "Enable Mailchimp debug badge (temporary)", "default": false, "info": "Enable to surface Shopify contact diagnostics (beacon, fetch, iframe logs) for troubleshooting." },
 
     { "type": "checkbox", "id": "use_mailchimp_flow", "label": "Add contacts to Mailchimp directly on submit", "default": true },
     { "type": "url",      "id": "mailchimp_action",  "label": "Mailchimp embed form action (Hosted or Embed URL)" },


### PR DESCRIPTION
## Summary
- persist Shopify contact helper debug logs on `window.nbShopifyDebug` with richer beacon, fetch, and iframe details
- add guarded console debugging for fallback contact posts in the dual-post and Surge Signature quiz flows
- document that enabling the Mailchimp debug badge also activates the extended diagnostics

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d18dcfa064833195b339ea1e7c60fe