### PR TITLE
Reliable Shopify customer creation (quiz + contact)

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -506,9 +506,7 @@ It:
 </script>
 {% render 'nb-sticky-cta-controller' %}
 {% render 'nb-anim-init' %}
-{% if request.path contains '/pages/contact' %}
-  <script src="{{ 'nb-contact-dualpost.js' | asset_url }}" defer></script>
-{% endif %}
 {% render 'nb-newsletter-proxy' %}
+{% render 'nb-customer-intake' %}
   </body>
 </html>

--- a/sections/nb-quiz-surgesignature.liquid
+++ b/sections/nb-quiz-surgesignature.liquid
@@ -38,18 +38,6 @@
     };
   </script>
 
-  <div class="nb-hidden" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden">
-    <iframe name="nb-shopify-target" id="nb-shopify-target" title="nb-shopify-target"></iframe>
-    {% form 'customer', id: 'nb-shopify-form', class: 'nb-shopify-form', target: 'nb-shopify-target', novalidate: 'novalidate' %}
-      <input type="email" name="contact[email]" id="nb-sf-email">
-      <input type="text" name="contact[first_name]" id="nb-sf-fname">
-      <input type="text" name="contact[last_name]" id="nb-sf-lname">
-      <input type="tel" name="contact[phone]" id="nb-sf-phone">
-      <input type="hidden" name="contact[tags]" id="nb-sf-tags" value="">
-      <input type="hidden" name="contact[accepts_marketing]" id="nb-sf-accepts" value="false">
-      <!-- accepts_marketing will be implied by submitting only when consent is checked -->
-    {% endform %}
-  </div>
 </section>
 
 {% schema %}

--- a/snippets/nb-customer-intake.liquid
+++ b/snippets/nb-customer-intake.liquid
@@ -1,0 +1,45 @@
+{% comment %}
+Global customer intake helper (hidden form + overlay).
+Used by nb-contact.js via window.nbSubmitShopifyContact().
+{% endcomment %}
+
+<style>
+  [data-nb-captcha-overlay]{
+    position:fixed; inset:0; display:flex; align-items:center; justify-content:center;
+    padding:clamp(16px,5vw,40px); background:rgba(15,23,42,.55); z-index:9999;
+  }
+  [data-nb-captcha-overlay][hidden]{ display:none !important; }
+  .nb-captcha-overlay__dialog{
+    background:#fff; color:#0f172a; width:min(640px,100%); border-radius:20px;
+    box-shadow:0 28px 64px rgba(15,23,42,.24); padding:clamp(20px,4vw,32px);
+  }
+  .nb-captcha-overlay__header{ display:flex; align-items:flex-start; justify-content:space-between; gap:12px; }
+  .nb-captcha-overlay__frame iframe{ width:100%; height:320px; border:1px solid #e5e7eb; border-radius:12px; background:#fff; }
+  .nb-captcha-overlay__close{ appearance:none; background:#f1f5f9; border:1px solid #e2e8f0; color:#0f172a; border-radius:10px; padding:8px 12px; cursor:pointer; }
+</style>
+
+<div data-nb-captcha-overlay hidden aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="nb-captcha-title">
+  <div class="nb-captcha-overlay__dialog">
+    <div class="nb-captcha-overlay__header">
+      <h2 id="nb-captcha-title">Almost there…</h2>
+      <button type="button" class="nb-captcha-overlay__close" data-nb-captcha-close>Close</button>
+    </div>
+    <p>Shopify sometimes asks for a quick human check. Complete the prompt below to finish.</p>
+    <div class="nb-captcha-overlay__frame" data-nb-captcha-frame>
+      <iframe id="HiddenNewsletterFrame" name="HiddenNewsletterFrame" title="Verification" loading="lazy"></iframe>
+    </div>
+  </div>
+</div>
+
+<div aria-hidden="true" style="position:absolute; left:-9999px; top:auto; width:1px; height:1px; overflow:hidden;">
+  {% form 'customer', id: 'NibanaHiddenNewsletter', target: 'HiddenNewsletterFrame', novalidate: 'novalidate' %}
+    <input type="email"  name="contact[email]"        id="HiddenCustomerEmail">
+    <input type="text"   name="contact[first_name]"   id="HiddenCustomerFirstName">
+    <input type="text"   name="contact[last_name]"    id="HiddenCustomerLastName">
+    <input type="text"   name="contact[name]"         id="HiddenCustomerName">
+    <input type="tel"    name="contact[phone]"        id="HiddenCustomerPhone">
+    <input type="hidden" name="contact[tags]"         id="HiddenCustomerTags" value="">
+    <input type="hidden" name="contact[accepts_marketing]" id="HiddenCustomerAcceptsMarketing" value="false">
+    <button id="HiddenCustomerSubmit" type="submit">Submit</button>
+  {% endform %}
+</div>


### PR DESCRIPTION
- Adds site-wide hidden {% form 'customer' %} with captcha overlay (`nb-customer-intake.liquid`); included in `theme.liquid`.
- Quiz & Contact now create a Shopify customer every time (subscribe only if consent checked).
- Both fallbacks post with `form_type=customer` and set `contact[accepts_marketing]`.
- Mailchimp embeds unchanged.

------
https://chatgpt.com/codex/tasks/task_e_68d1aa5187bc8331a309419691b62c0d