### PR TITLE
Make call CTA link configurable

### DIFF
--- a/sections/nibana-contact.liquid
+++ b/sections/nibana-contact.liquid
@@ -24,10 +24,14 @@ Also mirrors to:
       <div class="nb-card">
         <h2 class="nb-h3">{{ section.settings.call_heading | default: 'Prefer to talk?' | escape }}</h2>
         <p>{{ section.settings.call_sub | default: 'Book a free 20-minute discovery call.' | escape }}</p>
+        {% assign call_cta_link = section.settings.call_link %}
+        {% if call_cta_link == blank %}
+          {% assign call_cta_link = '/pages/contact' %}
+        {% endif %}
         <p>
           <a
             class="nb-btn nb-btn--primary"
-            href="{{ section.settings.call_link | default: '/pages/contact' | escape }}"
+            href="{{ call_cta_link | escape }}"
           >
             {{ section.settings.call_label | default: 'Book a Free 20-min Call' | escape }}
           </a>


### PR DESCRIPTION
## Summary
- compute the call-to-action link from the section setting with a fallback
- keep existing button styling and label behavior intact

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d1bf75b4848331a6a352cdf9c3c348