### PR TITLE
Split contact name fields and sync mirrors

### DIFF
--- a/assets/nb-contact.js
+++ b/assets/nb-contact.js
@@ -2,21 +2,31 @@
   const cf = document.getElementById('nb-contact-form');
   if (!cf) return;
 
+  const setValue = function (id, value) {
+    const el = document.getElementById(id);
+    if (el) el.value = value;
+    return el;
+  };
+
   cf.addEventListener('submit', function () {
     const fname = document.getElementById('nbc-first')?.value || '';
     const lname = document.getElementById('nbc-last')?.value || '';
     const email = document.getElementById('nbc-email')?.value || '';
     const phone = document.getElementById('nbc-phone')?.value || '';
     const consent = !!document.getElementById('nbc-consent')?.checked;
+    const fullname = `${fname} ${lname}`.trim();
+
+    setValue('nbc-name', fullname);
 
     // ----- Shopify Customer mirror (fire-and-forget)
     const sf = document.getElementById('nb-contact-customer');
     if (sf) {
-      document.getElementById('nbc-cust-email').value = email;
-      document.getElementById('nbc-cust-f').value     = fname;
-      document.getElementById('nbc-cust-l').value     = lname;
-      document.getElementById('nbc-cust-phone').value = phone;
-      document.getElementById('nbc-cust-acc').value   = consent ? 'true' : 'false';
+      setValue('nbc-cust-email', email);
+      setValue('nbc-cust-f', fname);
+      setValue('nbc-cust-l', lname);
+      setValue('nbc-cust-name', fullname);
+      setValue('nbc-cust-phone', phone);
+      setValue('nbc-cust-acc', consent ? 'true' : 'false');
 
       // add newsletter to tags if consented
       const t = document.getElementById('nbc-cust-tags');
@@ -29,10 +39,10 @@
     // ----- Mailchimp mirror (parallel)
     const mc = document.getElementById('nbc-mc');
     if (mc) {
-      document.getElementById('nbc-mc-fname').value = fname;
-      document.getElementById('nbc-mc-lname').value = lname;
-      document.getElementById('nbc-mc-email').value = email;
-      document.getElementById('nbc-mc-phone').value = phone;
+      setValue('nbc-mc-fname', fname);
+      setValue('nbc-mc-lname', lname);
+      setValue('nbc-mc-email', email);
+      setValue('nbc-mc-phone', phone);
       if (mc.requestSubmit) mc.requestSubmit(); else mc.submit();
     }
 

--- a/sections/nibana-contact.liquid
+++ b/sections/nibana-contact.liquid
@@ -68,9 +68,16 @@ Also mirrors to:
       {% form 'contact', id: 'nb-contact-form', class: 'nb-card nb-contact__form', novalidate: 'novalidate' %}
         <div class="nb-form-grid">
           <div class="nb-field nb-field--full">
-            <label class="nb-label" for="nbc-name">{{ section.settings.label_name | default: 'Name' | escape }} <span aria-hidden="true">*</span></label>
-            <input class="nb-input" id="nbc-name" name="contact[name]" type="text" required>
+            <label class="nb-label" for="nbc-first">First name <span aria-hidden="true">*</span></label>
+            <input class="nb-input" id="nbc-first" name="contact[first_name]" type="text" required>
           </div>
+
+          <div class="nb-field nb-field--full">
+            <label class="nb-label" for="nbc-last">Last name <span aria-hidden="true">*</span></label>
+            <input class="nb-input" id="nbc-last" name="contact[last_name]" type="text" required>
+          </div>
+
+          <input type="hidden" id="nbc-name" name="contact[name]">
 
           <div class="nb-field nb-field--full">
             <label class="nb-label" for="nbc-email">{{ section.settings.label_email | default: 'Email' | escape }} <span aria-hidden="true">*</span></label>
@@ -131,7 +138,9 @@ Also mirrors to:
       <div aria-hidden="true" style="position:absolute; left:-9999px; top:auto; width:1px; height:1px; overflow:hidden;">
         {% form 'customer', id: 'nb-contact-customer', target: 'nbc-shopify-target', novalidate: 'novalidate' %}
           <input type="email"  id="nbc-cust-email"  name="contact[email]">
-          <input type="text"   id="nbc-cust-name"  name="contact[name]">
+          <input type="text"   id="nbc-cust-f"      name="contact[first_name]">
+          <input type="text"   id="nbc-cust-l"      name="contact[last_name]">
+          <input type="text"   id="nbc-cust-name"   name="contact[name]">
           <input type="tel"    id="nbc-cust-phone" name="contact[phone]">
           <input type="hidden" id="nbc-cust-tags"  name="contact[tags]" value="Source: /contact">
           <input type="hidden" id="nbc-cust-acc"   name="contact[accepts_marketing]" value="false">


### PR DESCRIPTION
## Summary
- replace the single contact name field with separate first and last inputs while keeping a hidden combined value
- extend the hidden Shopify customer form to mirror separate names alongside the combined field
- update the contact JavaScript helper to fill the new fields safely and guard optional mirrors

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d1c5fa401c8331868548e580667576