### PR TITLE
Gate Mailchimp submits on consent

### DIFF
--- a/assets/nb-contact.js
+++ b/assets/nb-contact.js
@@ -52,13 +52,21 @@
 
     // ----- Mailchimp mirror (parallel)
     const mc = document.getElementById('nbc-mc');
-    if (mc && consent) {
-      setValue('nbc-mc-fname', fname);
-      setValue('nbc-mc-lname', lname);
-      setValue('nbc-mc-email', email);
-      setValue('nbc-mc-phone', phone);
-      setValue('nbc-mc-consent', consent ? '1' : '0');
-      if (mc.requestSubmit) mc.requestSubmit(); else mc.submit();
+    if (mc) {
+      if (consent) {
+        setValue('nbc-mc-fname', fname);
+        setValue('nbc-mc-lname', lname);
+        setValue('nbc-mc-email', email);
+        setValue('nbc-mc-phone', phone);
+        setValue('nbc-mc-consent', '1');
+        if (mc.requestSubmit) mc.requestSubmit(); else mc.submit();
+      } else {
+        setValue('nbc-mc-fname', '');
+        setValue('nbc-mc-lname', '');
+        setValue('nbc-mc-email', '');
+        setValue('nbc-mc-phone', '');
+        setValue('nbc-mc-consent', '0');
+      }
     }
 
     // IMPORTANT: do not preventDefault(); Shopify customer form will submit

--- a/assets/nb-quiz-surgesignature.js
+++ b/assets/nb-quiz-surgesignature.js
@@ -198,17 +198,29 @@
     // Submit Mailchimp in parallel
     const mc = document.getElementById('nbq-mc');
     if (mc) {
-      document.getElementById('nbq-mc-fname').value = fname;
-      document.getElementById('nbq-mc-lname').value = lname;
-      document.getElementById('nbq-mc-email').value = email;
-      document.getElementById('nbq-mc-phone').value = phone;
-      document.getElementById('nbq-mc-style').value = styleLabel;
+      if (consent) {
+        document.getElementById('nbq-mc-fname').value = fname;
+        document.getElementById('nbq-mc-lname').value = lname;
+        document.getElementById('nbq-mc-email').value = email;
+        document.getElementById('nbq-mc-phone').value = phone;
+        document.getElementById('nbq-mc-style').value = styleLabel;
 
-      document.getElementById('nbq-mc-acc').checked  = (styleLabel === 'Accelerator');
-      document.getElementById('nbq-mc-stab').checked = (styleLabel === 'Stabiliser');
-      document.getElementById('nbq-mc-def').checked  = (styleLabel === 'Defuser');
+        document.getElementById('nbq-mc-acc').checked  = (styleLabel === 'Accelerator');
+        document.getElementById('nbq-mc-stab').checked = (styleLabel === 'Stabiliser');
+        document.getElementById('nbq-mc-def').checked  = (styleLabel === 'Defuser');
 
-      if (mc.requestSubmit) mc.requestSubmit(); else mc.submit();
+        if (mc.requestSubmit) mc.requestSubmit(); else mc.submit();
+      } else {
+        document.getElementById('nbq-mc-fname').value = '';
+        document.getElementById('nbq-mc-lname').value = '';
+        document.getElementById('nbq-mc-email').value = '';
+        document.getElementById('nbq-mc-phone').value = '';
+        document.getElementById('nbq-mc-style').value = '';
+
+        document.getElementById('nbq-mc-acc').checked  = false;
+        document.getElementById('nbq-mc-stab').checked = false;
+        document.getElementById('nbq-mc-def').checked  = false;
+      }
     }
 
     // Persist for thank-you / rehydration


### PR DESCRIPTION
## Summary
- gate the contact Mailchimp mirror so it only populates and submits when consent is granted
- clear Mailchimp fields when consent is not provided to avoid accidental submissions
- mirror the same consent checks in the quiz flow, clearing style selections without submitting when opt-out

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d1d464ad94833191ae53627f720825