### PR TITLE
Remove stray endif from hidden Mailchimp form

### DIFF
--- a/sections/nb-quiz-surgesignature.liquid
+++ b/sections/nb-quiz-surgesignature.liquid
@@ -153,7 +153,6 @@
               <input type="submit" value="Subscribe">
             </form>
             <iframe name="nbq-mc-target" id="nbq-mc-target" title="Mailchimp submit" hidden></iframe>
-          {% endif %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove the unmatched Liquid `{% endif %}` after the hidden Mailchimp mirror form in the quiz section so the block structure stays balanced

## Testing
- theme-check

------
https://chatgpt.com/codex/tasks/task_e_68d1d742957c8331ab0fa212361a916d