### PR TITLE
Polish contact layout panels

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -5572,3 +5572,94 @@ body.nb-typography{
 .nb-contact .nb-btn--primary:hover{ background: var(--nb-choc-600,#b85f23); }
 .nb-contact .nb-btn--teal{ background: var(--nb-teal-700,#0f5b62); color:#fff; width:100%; }
 .nb-contact .nb-btn--teal:hover{ background: var(--nb-teal,#10636c); }
+/* === Nibana Contact page — Live polish (scoped) === */
+.nb-contact {
+  /* top space */
+  padding-top: clamp(28px, 6vw, 64px);
+}
+
+/* Two-column grid */
+.nb-contact .nb-grid.cols-2 {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: clamp(16px, 2.2vw, 28px);
+}
+@media (min-width: 992px) {
+  .nb-contact .nb-grid.cols-2 {
+    grid-template-columns: 1.05fr 1fr;
+    align-items: start;
+  }
+}
+
+/* Big tray cards (both sides share the same glossy look) */
+.nb-contact .nb-card.nb-card--panel {
+  background: #eef6f5; /* soft teal tint like live */
+  border: 1px solid rgba(16,99,108,.12);
+  border-radius: 20px;
+  padding: clamp(18px, 2.2vw, 24px);
+  box-shadow: 0 18px 36px rgba(0,0,0,.08);
+  transition: box-shadow .25s ease, transform .25s ease;
+}
+.nb-contact .nb-card.nb-card--panel:hover {
+  box-shadow: 0 22px 48px rgba(0,0,0,.10);
+  transform: translateY(-1px);
+}
+
+/* Nested soft cards on the left */
+.nb-contact .nb-card.nb-card--soft {
+  background: #f3f7f6;
+  border: 1px solid rgba(16,99,108,.10);
+  border-radius: 16px;
+  padding: clamp(16px, 2vw, 22px);
+  box-shadow: 0 8px 24px rgba(0,0,0,.06);
+  margin-top: 14px;
+}
+
+/* Headings and kicker (match live tone & spacing) */
+.nb-contact .nb-h1 { margin: 0 0 6px; color: #0e4f56; font-weight: 800; line-height: 1.06; }
+.nb-contact .nb-kicker { margin: 0 0 14px; opacity: .85; }
+.nb-contact .nb-h3 { margin: 0 0 8px; color: #153c3f; }
+
+/* Right form tray specifics */
+.nb-contact .nb-contact__form { background: #eaf5f4; }
+
+/* Fields */
+.nb-contact .nb-form-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 14px 18px;
+}
+.nb-contact .nb-field { width: 100%; }
+.nb-contact .nb-label { display: block; margin: 0 0 6px; font-weight: 600; color: #153c3f; }
+.nb-contact .nb-input {
+  width: 100%;
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(16,99,108,.22);
+  background: #fff;
+  box-shadow: 0 1px 0 rgba(0,0,0,.02);
+}
+.nb-contact .nb-input:focus {
+  outline: 0;
+  border-color: #10636c;
+  box-shadow: 0 0 0 3px rgba(16,99,108,.12);
+}
+.nb-contact select.nb-input { appearance: none; }
+.nb-contact textarea.nb-input { min-height: 140px; resize: vertical; }
+
+/* Consent row (checkbox, copy, help text) */
+.nb-contact .nb-consent { margin: 8px 0 12px; }
+.nb-contact .nb-checkbox { display: grid; grid-template-columns: 20px 1fr; gap: 10px 12px; align-items: start; }
+.nb-contact .nb-checkbox input { width: 20px; height: 20px; accent-color: #10636c; border-radius: 6px; }
+.nb-contact .nb-form-help { grid-column: 1 / -1; color: #5b6a72; font-size: .95em; margin: 6px 0 0; }
+
+/* Buttons */
+.nb-contact .nb-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  padding: 12px 22px; border-radius: 9999px; font-weight: 600; text-decoration: none; border: 0;
+  box-shadow: 0 10px 28px rgba(0,0,0,.06);
+}
+.nb-contact .nb-btn--primary { background: #d16c28; color: #fff; }           /* orange CTA on left */
+.nb-contact .nb-btn--primary:hover { background: #b85f23; }
+.nb-contact .nb-btn--teal { background: #10636c; color: #fff; width: 100%; }  /* teal Submit on right */
+.nb-contact .nb-btn--teal:hover { background: #0b4f57; }

--- a/sections/nibana-contact.liquid
+++ b/sections/nibana-contact.liquid
@@ -32,40 +32,28 @@ Also mirrors to:
   <div class="nb-grid cols-2">
     <!-- Left column -->
     <div class="nb-panel">
-      <h1 class="nb-h1">{{ section.settings.heading | default: 'Contact Us' | escape }}</h1>
-      <p class="nb-kicker">{{ section.settings.subheading | default: "Feel free to ask us anything. We're here to help." | escape }}</p>
+      <div class="nb-card nb-card--panel nb-contact__left-tray">
+        <h1 class="nb-h1">Contact Us</h1>
+        <p class="nb-kicker">Feel free to ask us anything. We're here to help.</p>
 
-      <div class="nb-card">
-        <h2 class="nb-h3">{{ section.settings.details_heading | default: 'Contact Details' | escape }}</h2>
-        <p>
-          {{ section.settings.details_email | default: 'info@nibana.life' | escape }}<br>
-          {{ section.settings.details_phone | default: '+44 20 7173 5775' | escape }}
-        </p>
-        <p>{{ section.settings.details_note | default: 'We usually reply within 1 business day.' | escape }}</p>
-      </div>
+        <div class="nb-card nb-card--soft">
+          <h2 class="nb-h3">Contact Details</h2>
+          <p>info@nibana.life<br>+44 20 7173 5775</p>
+          <p>We usually reply within 1 business day.</p>
+        </div>
 
-      <div class="nb-card">
-        <h2 class="nb-h3">{{ section.settings.call_heading | default: 'Prefer to talk?' | escape }}</h2>
-        <p>{{ section.settings.call_sub | default: 'Book a free 20-minute discovery call.' | escape }}</p>
-        {% assign call_cta_link = section.settings.call_link %}
-        {% if call_cta_link == blank %}
-          {% assign call_cta_link = '/pages/contact' %}
-        {% endif %}
-        <p>
-          <a
-            class="nb-cta"
-            href="{{ call_cta_link | escape }}"
-          >
-            {{ section.settings.call_label | default: 'Book a Free 20-min Call' | escape }}
-          </a>
-        </p>
+        <div class="nb-card nb-card--soft">
+          <h2 class="nb-h3">Prefer to talk?</h2>
+          <p>Book a free 20-minute discovery call.</p>
+          <p><a class="nb-btn nb-btn--primary" href="/pages/contact">Book a Free 20-min Call</a></p>
+        </div>
       </div>
     </div>
 
     <!-- Right column -->
     <div class="nb-panel">
       {%- comment -%} VISIBLE: Shopify CUSTOMER form (creates/updates customer) {%- endcomment -%}
-      {% form 'customer', id: 'nb-contact-shopify', class: 'nb-card nb-contact__form', novalidate: 'novalidate' %}
+      {% form 'customer', id: 'nb-contact-shopify', class: 'nb-card nb-card--panel nb-contact__form', novalidate: 'novalidate' %}
         <div class="nb-form-grid">
           <div class="nb-field nb-field--full">
             <label class="nb-label" for="nbc-first">First name <span aria-hidden="true">*</span></label>


### PR DESCRIPTION
## Summary
- wrap the contact page intro column in a glossy tray card with updated static content
- upgrade the visible contact form to use the glossy panel treatment while preserving all fields
- add scoped contact page styles for the refreshed tray cards, grid, and button treatments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d258741a888331aa6ceb7461b86e52