### PR TITLE
Ensure contact section clears sticky header

### DIFF
--- a/assets/nb-contact.css
+++ b/assets/nb-contact.css
@@ -3,6 +3,7 @@
   max-width: var(--nb-contact-max-width, 1100px);
   margin-inline: auto;
   padding: var(--nb-contact-section-padding, 48px 16px);
+  padding-block-start: clamp(80px, 10vw, 140px);
 }
 
 .nb-contact .nb-grid{


### PR DESCRIPTION
## Summary
- add an explicit top padding clamp to the contact section so it aligns with quiz panel spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d25d168ad48331aeabb780dbbbe19f