### PR TITLE
Adjust contact section top padding

### DIFF
--- a/sections/nibana-contact.liquid
+++ b/sections/nibana-contact.liquid
@@ -27,6 +27,7 @@ Also mirrors to:
     --nb-contact-card-radius: {{ nb_card_radius }};
     --nb-contact-card-padding: {{ nb_card_padding }};
     --nb-contact-card-shadow: {{ nb_card_shadow }};
+    padding-block-start: clamp(80px, 10vw, 140px);
   "
 >
   <div class="nb-grid cols-2">


### PR DESCRIPTION
## Summary
- ensure the contact section always clears the sticky header by adding a clamp-based top padding in the inline styles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2601b9b448331acbfe3df8c0623cb