### PR TITLE
Contact: add top safety gap on #shopify-section-… (match quiz pattern)

### DIFF
--- a/assets/nb-contact.css
+++ b/assets/nb-contact.css
@@ -3,6 +3,7 @@
   max-width: var(--nb-contact-max-width, 1100px);
   margin-inline: auto;
   padding: var(--nb-contact-section-padding, 48px 16px);
+  padding-block-start: clamp(80px, 10vw, 140px);
 }
 
 .nb-contact .nb-grid{

--- a/sections/nibana-contact.liquid
+++ b/sections/nibana-contact.liquid
@@ -16,6 +16,17 @@ Also mirrors to:
   assign nb_card_soft_bg = nb_card_bg | color_lighten: 8
 %}
 
+{%- comment -%} Top safety gap for this section (on the Shopify wrapper) {%- endcomment -%}
+<style>
+  #shopify-section-{{ section.id }}{
+    /* creates real space ABOVE the section, outside of its background */
+    margin-top: clamp(28px, 6vw, 96px);
+  }
+  @media (min-width: 990px){
+    #shopify-section-{{ section.id }}{ margin-top: clamp(36px, 7vw, 110px); }
+  }
+</style>
+
 <section
   class="nb-shell nb-contact"
   style="


### PR DESCRIPTION
## Summary
- add a wrapper-scoped style that clamps the Shopify section margin top to match the quiz spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d25d168ad48331aeabb780dbbbe19f