### PR TITLE
Add client fallback thanks handling to Surge Signature quiz

### DIFF
--- a/assets/nb-quiz-surgesignature.js
+++ b/assets/nb-quiz-surgesignature.js
@@ -258,7 +258,41 @@
 })();
 
 (function(){
-  var thanks = document.getElementById('nb-quiz-thanks');
+  var gate = document.getElementById('nb-quiz-gate');
+  var form = document.getElementById('nb-quiz-shopify');
+  if (!gate || !form) return;
+
+  form.addEventListener('submit', function(){
+    try { localStorage.setItem('nb_quiz_submitted', '1'); } catch(_){ }
+  });
+
+  (function showThanksIfNeeded(){
+    var qs = new URLSearchParams(window.location.search);
+    var serverThanks = document.getElementById('nb-quiz-server-thanks');
+    var hasUrlSuccess =
+      qs.get('customer_posted') === 'true' ||
+      qs.get('form_type') === 'customer' ||
+      qs.get('contact_posted') === 'true';
+
+    if (serverThanks) {
+      try { localStorage.removeItem('nb_quiz_submitted'); } catch(_){ }
+      return;
+    }
+
+    var hadFlag = false;
+    try { hadFlag = localStorage.getItem('nb_quiz_submitted') === '1'; } catch(_){ }
+
+    if (!serverThanks && (hasUrlSuccess || hadFlag)) {
+      gate.classList.add('is-client-thanks');
+      try { localStorage.removeItem('nb_quiz_submitted'); } catch(_){ }
+      var t = document.getElementById('nb-quiz-client-thanks');
+      if (t) try { t.scrollIntoView({behavior:'smooth', block:'center'}); } catch(_){ }
+    }
+  })();
+})();
+
+(function(){
+  var thanks = document.getElementById('nb-quiz-server-thanks');
   if (!thanks) return;
   try {
     thanks.scrollIntoView({ behavior: 'smooth', block: 'center' });

--- a/sections/nb-quiz-surgesignature.liquid
+++ b/sections/nb-quiz-surgesignature.liquid
@@ -29,7 +29,7 @@
           <div class="nb-quiz__free-insight" data-nb-quiz-practice></div>
         </div>
 
-        <div class="nb-card nb-quiz__gate">
+        <div id="nb-quiz-gate" class="nb-card nb-quiz__gate">
           <style>
             /* ---- scoped, only within this section ---- */
             #nb-quiz-shopify.nb-quiz__form { padding: 20px; }
@@ -85,11 +85,15 @@
               box-shadow: 0 1px 0 rgba(15,23,42,.02) inset;
             }
             .nb-quiz__thanks h3{ margin: 0 0 8px; }
+
+            /* When we decide to show client fallback, hide the fieldset and show the client thanks */
+            #nb-quiz-gate.is-client-thanks .nb-quiz__fieldset{ display:none; }
+            #nb-quiz-gate.is-client-thanks #nb-quiz-client-thanks{ display:block; }
           </style>
 
           {% form 'customer', id: 'nb-quiz-shopify', class: 'nb-quiz__form', novalidate: 'novalidate' %}
             {% if form.posted_successfully? %}
-              <div class="nb-quiz__thanks" id="nb-quiz-thanks">
+              <div id="nb-quiz-server-thanks" class="nb-quiz__thanks">
                 <h3>Check your inbox ✉️</h3>
                 <p>We’ve sent your 2-page playbook. If it’s not there, check Promotions/Spam.</p>
                 <p><a class="nb-link" href="/pages/surge-signature-result">View your result on Nibana →</a></p>
@@ -132,6 +136,12 @@
               </div>
             {% endif %}
           {% endform %}
+
+          <div id="nb-quiz-client-thanks" class="nb-quiz__thanks" style="display:none">
+            <h3>Check your inbox ✉️</h3>
+            <p>We’ve emailed your 2-page playbook. If it’s not there, check Promotions/Spam.</p>
+            <p><a class="nb-link" href="/pages/surge-signature-result">View your result on Nibana →</a></p>
+          </div>
         </div>
 
             <!-- Hidden Mailchimp mirror — submitted in parallel via JS -->


### PR DESCRIPTION
## Summary
- tag the Surge Signature quiz gate and server-rendered thanks for client detection
- add a hidden client-side thank-you fallback and supporting scoped styles
- detect captcha round-trips in JS to surface the fallback message when needed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d26f806f2c8331864676a9024a804a