### PR TITLE
Remove redundant nb-contact script from quiz section

### DIFF
--- a/sections/nb-quiz-surgesignature.liquid
+++ b/sections/nb-quiz-surgesignature.liquid
@@ -169,7 +169,6 @@
   </div>
 
   <script src="{{ 'nb-quiz-surgesignature.js' | asset_url }}" defer></script>
-  <script src="{{ 'nb-contact.js' | asset_url }}" defer></script>
   <link rel="stylesheet" href="{{ 'nb-quiz-surgesignature.css' | asset_url }}" media="all">
   <script>
     window.NB_QUIZ = window.NB_QUIZ || {};


### PR DESCRIPTION
## Summary
- remove the nb-contact.js include from the Surge Signature quiz section to avoid duplicate loads
- rely on the existing global include in theme.liquid so quiz and contact logic continues to work

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d29c5ae1808331b68cc31c2cdf15b0