### PR TITLE
Fix blog post fallback tag comparison

### DIFF
--- a/blocks/_blog-post-card.liquid
+++ b/blocks/_blog-post-card.liquid
@@ -36,7 +36,8 @@
   {%- for t in article.tags -%}
     {%- assign t_down = t | downcase -%}
     {%- for k in known -%}
-      {%- if t_down == k | downcase -%}{%- assign cat_fallback = t -%}{%- break -%}{%- endif -%}
+      {%- assign k_down = k | downcase -%}
+      {%- if t_down == k_down -%}{%- assign cat_fallback = t -%}{%- break -%}{%- endif -%}
     {%- endfor -%}
     {%- if cat_fallback != '' -%}{%- break -%}{%- endif -%}
   {%- endfor -%}


### PR DESCRIPTION
## Summary
- cache a downcased copy of each known category tag during fallback matching
- compare the downcased article tag to the cached value to avoid Liquid syntax errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2e0bf9144833194ffd9adce63965e