### PR TITLE
Blog filters: centered layout, elegant chips, compact search, top-6 subtopics

### DIFF
--- a/assets/nb-blog-filter.css
+++ b/assets/nb-blog-filter.css
@@ -1,8 +1,57 @@
-.nb-blog-filter { margin: clamp(12px, 3vw, 20px) 0 8px; }
-.nb-filter-row { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin-bottom: 10px; }
-.nb-chip { padding: 6px 12px; border-radius: 999px; border: 1px solid rgba(0,0,0,.12); background: #fff; cursor: pointer; }
-.nb-chip--on { border-color: rgba(0,0,0,.24); box-shadow: 0 2px 8px rgba(0,0,0,.06); }
-.nb-subtopic-input { flex: 1; min-width: 220px; padding: 8px 10px; border-radius: 999px; border: 1px solid rgba(0,0,0,.12); }
-.nb-clear { padding: 6px 10px; border-radius: 999px; border: 1px solid rgba(0,0,0,.12); background: #fff; }
-.nb-filter-row--popular { gap: 6px; }
-.nb-chip[hidden], .nb-filter-row[hidden], .nb-clear[hidden] { display: none !important; }
+/* Container + layout */
+.nb-blog-filter{
+  max-width: var(--normal-content-width, 980px);
+  margin: clamp(12px, 3vw, 24px) auto 0;
+  padding: 0 clamp(8px, 2vw, 12px);
+}
+
+.nb-filter-row{
+  display:flex; flex-wrap:wrap; gap:10px; align-items:center; justify-content:center;
+  margin-bottom: clamp(10px, 2.5vw, 16px);
+}
+
+/* Category chips row sits closer to hero; search has a little more gap */
+.nb-filter-row--cats{ margin-top: 2px; }
+.nb-filter-row--search{ gap:12px; }
+.nb-filter-row--popular{ gap:8px; }
+
+/* Chips */
+.nb-chip{
+  --chip-bg: #fff;
+  --chip-border: rgba(0,0,0,.12);
+  --chip-shadow: 0 2px 10px rgba(0,0,0,.06);
+  --chip-shadow-active: 0 4px 14px rgba(0,0,0,.10);
+  appearance:none; border:1px solid var(--chip-border); background:var(--chip-bg);
+  border-radius:999px; padding:10px 14px; font:inherit; cursor:pointer;
+  transition: box-shadow .2s ease, transform .06s ease, border-color .2s ease, background .2s ease;
+}
+.nb-chip:hover{ box-shadow: var(--chip-shadow); }
+.nb-chip:active{ transform: translateY(1px); }
+.nb-chip--on{
+  background: #fff;
+  border-color: rgba(0,0,0,.24);
+  box-shadow: var(--chip-shadow-active);
+}
+
+/* Search field */
+.nb-subtopic-input{
+  width: min(520px, 80vw);
+  min-width: 240px;
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(0,0,0,.12);
+  background: #fff;
+  text-align: center;
+}
+.nb-subtopic-input:focus{ outline: none; box-shadow: 0 0 0 3px rgba(12,138,123,.14); }
+
+.nb-clear{
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(0,0,0,.12);
+  background: #fff;
+  cursor: pointer;
+}
+
+/* Utility */
+.nb-chip[hidden], .nb-filter-row[hidden], .nb-clear[hidden]{ display:none !important; }

--- a/assets/nb-blog-filter.js
+++ b/assets/nb-blog-filter.js
@@ -2,6 +2,8 @@
   const qs = (s, r=document) => r.querySelector(s);
   const qsa = (s, r=document) => Array.from(r.querySelectorAll(s));
 
+  const MAX_POPULAR = 6; // show at most 6 curated popular subtopics
+
   function slugify(s) {
     return (s || '').toString().trim().toLowerCase()
       .replace(/\u2019/g, "'") // smart apostrophe
@@ -49,7 +51,11 @@
     // Popular subtopics (top N by frequency)
     const freq = {};
     cardData.forEach(c => c.topicsSlug.forEach(t => { freq[t]=(freq[t]||0)+1; }));
-    const popular = Object.entries(freq).sort((a,b)=>b[1]-a[1]).slice(0,8).map(([t])=>t).filter(Boolean);
+    const popular = Object.entries(freq)
+      .sort((a,b)=>b[1]-a[1])
+      .slice(0, MAX_POPULAR)
+      .map(([t])=>t)
+      .filter(Boolean);
     if (popular.length) {
       popularRow.hidden = false;
       popular.forEach(t => {


### PR DESCRIPTION
## Summary
- Centers category chips, search input, and popular subtopics.
- Adds elevated chip hover/active states; keeps All as default.
- Limits popular subtopic chips to 6 (`MAX_POPULAR`).
- No changes to URL params or filtering logic.


------
https://chatgpt.com/codex/tasks/task_e_68d2e7ab99648331ba7a9ff11373801f