### PR TITLE
Article CTAs (mid+end) + mint panel, hide tags, upgraded Related Posts

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -5709,3 +5709,6 @@ body.nb-typography{
   box-shadow: 0 14px 32px rgba(16,99,108,.22);
 }
 
+
+.article-tags, .tag-list, .nb-article-tags { display: none !important; }
+.nb-related__grid{ display:grid; grid-template-columns:repeat(auto-fill, minmax(260px,1fr)); gap:16px; }

--- a/assets/nb-blog-cta.css
+++ b/assets/nb-blog-cta.css
@@ -1,0 +1,15 @@
+.nb-cta-wrap{ margin: clamp(24px, 5vw, 48px) 0; }
+.nb-cta{
+  background: var(--nb-mint, #e8fbf3);
+  border-radius: 16px;
+  box-shadow: 0 6px 18px rgba(0,0,0,.06);
+}
+.nb-cta-wrap--end .nb-cta{ background: var(--nb-pebble, #eef3f3); }
+.nb-cta__inner{ padding: clamp(16px, 3.5vw, 28px); }
+.nb-cta__title{ margin: 0 0 8px; font-size: clamp(1.1rem, 2.2vw, 1.35rem); line-height: 1.2; }
+.nb-cta__body{ margin: 0 0 16px; opacity: .9; }
+.nb-cta__nuance{ display:inline; opacity:.9; }
+.nb-cta__btn{
+  display:inline-block; padding:10px 16px; border-radius:999px; text-decoration:none;
+  background: var(--color-teal, #0c8a7b); color:#fff; font-weight:600;
+}

--- a/blocks/_blog-post-content.liquid
+++ b/blocks/_blog-post-content.liquid
@@ -2,7 +2,21 @@
 
 <div class="blog-post-content rte">
   <rte-formatter>
-    {{ article.content }}
+    {%- liquid
+      assign raw = article.content
+      assign parts = raw | split: '</p>'
+      assign total = parts | size
+      assign mid_index = total | times: 6 | divided_by: 10
+    -%}
+    {%- for part in parts -%}
+      {%- if part != '' -%}{{ part }}</p>{%- endif -%}
+      {%- if forloop.index == mid_index -%}
+        {%- render 'nb-article-ctas', mode: 'mid' -%}
+      {%- endif -%}
+    {%- endfor -%}
+    {%- if total <= 1 -%}
+      {%- render 'nb-article-ctas', mode: 'mid' -%}
+    {%- endif -%}
   </rte-formatter>
 </div>
 

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -7,6 +7,7 @@
     {%- render 'stylesheets' -%}
     {{ 'nb-visuals.css' | asset_url | stylesheet_tag }}
     {{ 'nb-blog-filter.css' | asset_url | stylesheet_tag }}
+    {{ 'nb-blog-cta.css' | asset_url | stylesheet_tag }}
 
     {%- if settings.favicon != blank -%}
       <link

--- a/sections/main-blog-post.liquid
+++ b/sections/main-blog-post.liquid
@@ -71,6 +71,7 @@
     {% endif %}
 
     {%- content_for 'block', id: 'blog-post-content', type: '_blog-post-content' -%}
+    {%- render 'nb-article-ctas', mode: 'end' -%}
 
     {%- comment -%}
       Inline CTA (optional): rendered into a template and injected via JS
@@ -126,79 +127,7 @@
       </div>
     </section>
 
-   {%- comment -%} === Related posts (by shared tags; fallback to recent) === {%- endcomment -%}
-{%- assign _shown = 0 -%}
-{%- capture related_markup -%}
-  <div class="nb-related__grid">
-  {%- for a in blog.articles -%}
-    {%- if a.id != article.id and _shown < 3 -%}
-      {%- assign _overlap = false -%}
-      {%- for t in article.tags -%}
-        {%- if a.tags contains t -%}{%- assign _overlap = true -%}{%- endif -%}
-      {%- endfor -%}
-      {%- if _overlap -%}
-        {%- liquid
-          assign _wa = a.content | strip_html | split: ' ' | size
-          assign _ma = _wa | divided_by: 200
-          assign _ra = _wa | modulo: 200
-          if _ra > 0
-            assign _ma = _ma | plus: 1
-          endif
-          if _ma < 1
-            assign _ma = 1
-          endif
-        -%}
-        <article class="nb-related__card">
-          <a class="nb-related__link" href="{{ a.url }}">
-            {%- if a.image -%}
-              {{ a | image_url: width: 800 | image_tag: alt: a.title, class: 'nb-related__img', sizes: '(max-width: 740px) 100vw, 360px', widths: '360,540,720,800' }}
-            {%- endif -%}
-            <h4 class="nb-related__title">{{ a.title }}</h4>
-            <p class="nb-related__meta">{{ a.published_at | date: "%b %e, %Y" }} · {{ _ma }} min read</p>
-          </a>
-        </article>
-        {%- assign _shown = _shown | plus: 1 -%}
-      {%- endif -%}
-    {%- endif -%}
-  {%- endfor -%}
-  </div>
-{%- endcapture -%}
-
-    <section class="nb-related">
-  <h3 class="nb-related__heading">Related reading</h3>
-  {%- if _shown > 0 -%}
-    {{ related_markup }}
-  {%- else -%}
-    <div class="nb-related__grid">
-    {%- assign _fallback_shown = 0 -%}
-    {%- for a in blog.articles -%}
-      {%- if a.id != article.id and _fallback_shown < 3 -%}
-        {%- liquid
-          assign _wa = a.content | strip_html | split: ' ' | size
-          assign _ma = _wa | divided_by: 200
-          assign _ra = _wa | modulo: 200
-          if _ra > 0
-            assign _ma = _ma | plus: 1
-          endif
-          if _ma < 1
-            assign _ma = 1
-          endif
-        -%}
-        <article class="nb-related__card">
-          <a class="nb-related__link" href="{{ a.url }}">
-            {%- if a.image -%}
-              {{ a | image_url: width: 800 | image_tag: alt: a.title, class: 'nb-related__img', sizes: '(max-width: 740px) 100vw, 360px', widths: '360,540,720,800' }}
-            {%- endif -%}
-            <h4 class="nb-related__title">{{ a.title }}</h4>
-            <p class="nb-related__meta">{{ a.published_at | date: "%b %e, %Y" }} · {{ _ma }} min read</p>
-          </a>
-        </article>
-        {%- assign _fallback_shown = _fallback_shown | plus: 1 -%}
-      {%- endif -%}
-    {%- endfor -%}
-    </div>
-  {%- endif -%}
-</section>
+    {%- render 'nb-related-posts', limit: 4 -%}
 
     <nav class="nb-article-nav" aria-label="Article pagination">
       {% assign has_prev = article.previous %}

--- a/snippets/nb-article-ctas.liquid
+++ b/snippets/nb-article-ctas.liquid
@@ -1,0 +1,161 @@
+{%- liquid
+  assign mode = mode | default: 'mid'
+
+  assign category = article.metafields.custom.primary_category | default: 'Relationships'
+  assign subtopics = article.metafields.custom.subtopics | default: nil
+
+  assign primary_type = article.metafields.custom.cta_primary_type | default: ''
+  assign secondary_type = article.metafields.custom.cta_secondary_type | default: ''
+
+  if primary_type == '' or secondary_type == ''
+    case category
+      when "Men’s Work"
+        assign cat_primary = 'call'
+        assign cat_secondary = 'leadmagnet'
+      when "Relationships"
+        assign cat_primary = 'leadmagnet'
+        assign cat_secondary = 'call'
+      when "Emotional Intelligence"
+        assign cat_primary = 'quiz'
+        assign cat_secondary = 'leadmagnet'
+      when "Leadership"
+        assign cat_primary = 'call'
+        assign cat_secondary = 'quiz'
+      when "Embodiment"
+        assign cat_primary = 'leadmagnet'
+        assign cat_secondary = 'call'
+      when "Sexuality"
+        assign cat_primary = 'quiz'
+        assign cat_secondary = 'leadmagnet'
+      when "Self-Discovery"
+        assign cat_primary = 'quiz'
+        assign cat_secondary = 'call'
+      else
+        assign cat_primary = 'leadmagnet'
+        assign cat_secondary = 'call'
+    endcase
+  endif
+
+  if primary_type == '' and cat_primary != blank
+    assign primary_type = cat_primary
+  endif
+  if secondary_type == '' and cat_secondary != blank
+    assign secondary_type = cat_secondary
+  endif
+
+  assign url_call_default = '/pages/book-a-call'
+  assign url_quiz_default = '/quiz'
+  assign url_leadmagnet_default = ''
+
+  assign url_primary = article.metafields.custom.cta_link | default: article.metafields.custom.cta_primary_url | default: ''
+  assign url_secondary = article.metafields.custom.cta_secondary_url | default: ''
+
+  if url_primary == ''
+    case primary_type
+      when 'call' assign url_primary = url_call_default
+      when 'quiz' assign url_primary = url_quiz_default
+      when 'leadmagnet' assign url_primary = url_leadmagnet_default
+      else assign url_primary = url_call_default
+    endcase
+  endif
+
+  if url_secondary == ''
+    case secondary_type
+      when 'call' assign url_secondary = url_call_default
+      when 'quiz' assign url_secondary = url_quiz_default
+      when 'leadmagnet' assign url_secondary = url_leadmagnet_default
+      else assign url_secondary = url_call_default
+    endcase
+  endif
+
+  if primary_type == 'leadmagnet' and url_primary == ''
+    assign primary_type = 'quiz'
+    assign url_primary = url_quiz_default
+  endif
+  if secondary_type == 'leadmagnet' and url_secondary == ''
+    assign secondary_type = 'call'
+    assign url_secondary = url_call_default
+  endif
+
+  assign copy_heading_call = "Ready for your next chapter?"
+  assign copy_body_call = "Let’s map what you want—and the first moves to get there."
+  assign copy_button_call = article.metafields.custom.cta_label | default: "Book a free 20-min call"
+
+  assign copy_heading_quiz = "Take the quick quiz"
+  assign copy_body_quiz = "Get a fast signal on where your energy patterns help—or hinder—connection."
+  assign copy_button_quiz = "Start the quiz"
+
+  assign copy_heading_leadmagnet = "Free guide: Core Beliefs → Freedom"
+  assign copy_body_leadmagnet = "Spot and shift the beliefs that keep you stuck. Practical, concise."
+  assign copy_button_leadmagnet = "Get the guide"
+
+  assign nuance = ''
+  if subtopics
+    for st in subtopics
+      case st
+        when 'Boundaries' assign nuance = "Includes a simple Boundaries practice you can try today."
+        when 'Repair' assign nuance = "Plus a 3-step micro-repair you can use after conflict."
+        when 'Desire' assign nuance = "Prompts to clarify your true desire—without shame."
+        when 'IFS' assign nuance = "Grounded in parts-work (IFS) to meet your inner dynamics."
+        when 'Shame' assign nuance = "Gentle, shame-aware language to keep your system safe."
+      endcase
+      if nuance != ''
+        break
+      endif
+    endfor
+  endif
+-%}
+
+{%- capture _cta_card -%}
+  <div class="nb-cta">
+    <div class="nb-cta__inner">
+      <h3 class="nb-cta__title">{{ heading }}</h3>
+      <p class="nb-cta__body">{{ body }}{% if nuance != '' %} <span class="nb-cta__nuance">{{ nuance }}</span>{% endif %}</p>
+      <a class="nb-cta__btn" href="{{ url }}">{{ button }}</a>
+    </div>
+  </div>
+{%- endcapture -%}
+
+{%- if mode == 'mid' -%}
+  {%- liquid
+    case primary_type
+      when 'call'
+        assign heading = copy_heading_call
+        assign body = copy_body_call
+        assign button = copy_button_call
+        assign url = url_primary
+      when 'quiz'
+        assign heading = copy_heading_quiz
+        assign body = copy_body_quiz
+        assign button = copy_button_quiz
+        assign url = url_primary
+      else
+        assign heading = copy_heading_leadmagnet
+        assign body = copy_body_leadmagnet
+        assign button = copy_button_leadmagnet
+        assign url = url_primary
+    endcase
+  -%}
+  <div class="nb-cta-wrap nb-cta-wrap--mid">{{ _cta_card }}</div>
+{%- else -%}
+  {%- liquid
+    case secondary_type
+      when 'call'
+        assign heading = copy_heading_call
+        assign body = copy_body_call
+        assign button = copy_button_call
+        assign url = url_secondary
+      when 'quiz'
+        assign heading = copy_heading_quiz
+        assign body = copy_body_quiz
+        assign button = copy_button_quiz
+        assign url = url_secondary
+      else
+        assign heading = copy_heading_leadmagnet
+        assign body = copy_body_leadmagnet
+        assign button = copy_button_leadmagnet
+        assign url = url_secondary
+    endcase
+  -%}
+  <div class="nb-cta-wrap nb-cta-wrap--end">{{ _cta_card }}</div>
+{%- endif -%}

--- a/snippets/nb-related-posts.liquid
+++ b/snippets/nb-related-posts.liquid
@@ -1,0 +1,69 @@
+{%- liquid
+  assign current = article
+  assign current_cat = article.metafields.custom.primary_category | default: ''
+  assign current_topics = article.metafields.custom.subtopics | default: '' 
+  assign take = limit | default: 4
+  assign picked_handles = '' 
+  assign shown = 0
+-%}
+
+{%- if blog.articles_count > 1 -%}
+  <section class="nb-related">
+    <h2 class="h2" style="margin: 24px 0;">Related posts</h2>
+    <div class="nb-related__grid">
+      {%- comment -%} Pass 1: same primary category {%- endcomment -%}
+      {%- for a in blog.articles -%}
+        {%- if a.id != current.id and shown < take -%}
+          {%- assign a_cat = a.metafields.custom.primary_category | default: '' -%}
+          {%- if a_cat != '' and a_cat == current_cat -%}
+            <div class="nb-related__item">
+              {% content_for 'block', id: 'static-blog-post-card', type: '_blog-post-card', article: a %}
+            </div>
+            {%- assign picked_handles = picked_handles | append: a.handle | append: ',' -%}
+            {%- assign shown = shown | plus: 1 -%}
+          {%- endif -%}
+        {%- endif -%}
+      {%- endfor -%}
+
+      {%- comment -%} Pass 2: share any subtopic {%- endcomment -%}
+      {%- if shown < take and current_topics != '' -%}
+        {%- assign topics_list = current_topics -%}
+        {%- for a in blog.articles -%}
+          {%- if a.id != current.id and shown < take -%}
+            {%- unless picked_handles contains a.handle -%}
+              {%- assign a_topics = a.metafields.custom.subtopics | default: '' -%}
+              {%- if a_topics != '' -%}
+                {%- assign match = false -%}
+                {%- for t in topics_list -%}
+                  {%- if a_topics contains t -%}{%- assign match = true -%}{%- break -%}{%- endif -%}
+                {%- endfor -%}
+                {%- if match -%}
+                  <div class="nb-related__item">
+                    {% content_for 'block', id: 'static-blog-post-card', type: '_blog-post-card', article: a %}
+                  </div>
+                  {%- assign picked_handles = picked_handles | append: a.handle | append: ',' -%}
+                  {%- assign shown = shown | plus: 1 -%}
+                {%- endif -%}
+              {%- endif -%}
+            {%- endunless -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- endif -%}
+
+      {%- comment -%} Pass 3: recent fallback {%- endcomment -%}
+      {%- if shown < take -%}
+        {%- for a in blog.articles -%}
+          {%- if a.id != current.id and shown < take -%}
+            {%- unless picked_handles contains a.handle -%}
+              <div class="nb-related__item">
+                {% content_for 'block', id: 'static-blog-post-card', type: '_blog-post-card', article: a %}
+              </div>
+              {%- assign picked_handles = picked_handles | append: a.handle | append: ',' -%}
+              {%- assign shown = shown | plus: 1 -%}
+            {%- endunless -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- endif -%}
+    </div>
+  </section>
+{%- endif -%}


### PR DESCRIPTION
## Summary
* Adds nb-article-ctas with mode support; injects mid & end CTAs.
* Defaults: Call `/pages/book-a-call`, Quiz `/quiz`; lead-magnet falls back if no URL present.
* Hides legacy tag list.
* Adds nb-related-posts (category-first, subtopic-boost, recent fallback).
* Styles: nb-blog-cta.css (mint/sage panel), nb-related__grid.
* No schema changes; uses existing blog-post metafields.

## Testing
* Not run (not requested).


------
https://chatgpt.com/codex/tasks/task_e_68d2f01752b883318fd6287349143c9c