### PR TITLE
Scope blog CTA panel styling

### DIFF
--- a/assets/nb-blog-cta.css
+++ b/assets/nb-blog-cta.css
@@ -1,15 +1,15 @@
 .nb-cta-wrap{ margin: clamp(24px, 5vw, 48px) 0; }
-.nb-cta{
+.nb-cta-panel{
   background: var(--nb-mint, #e8fbf3);
   border-radius: 16px;
   box-shadow: 0 6px 18px rgba(0,0,0,.06);
 }
-.nb-cta-wrap--end .nb-cta{ background: var(--nb-pebble, #eef3f3); }
-.nb-cta__inner{ padding: clamp(16px, 3.5vw, 28px); }
-.nb-cta__title{ margin: 0 0 8px; font-size: clamp(1.1rem, 2.2vw, 1.35rem); line-height: 1.2; }
-.nb-cta__body{ margin: 0 0 16px; opacity: .9; }
-.nb-cta__nuance{ display:inline; opacity:.9; }
-.nb-cta__btn{
+.nb-cta-wrap--end .nb-cta-panel{ background: var(--nb-pebble, #eef3f3); }
+.nb-cta-panel__inner{ padding: clamp(16px, 3.5vw, 28px); }
+.nb-cta-panel__title{ margin: 0 0 8px; font-size: clamp(1.1rem, 2.2vw, 1.35rem); line-height: 1.2; }
+.nb-cta-panel__body{ margin: 0 0 16px; opacity: .9; }
+.nb-cta-panel__nuance{ display:inline; opacity:.9; }
+.nb-cta-panel__btn{
   display:inline-block; padding:10px 16px; border-radius:999px; text-decoration:none;
   background: var(--color-teal, #0c8a7b); color:#fff; font-weight:600;
 }

--- a/snippets/nb-article-ctas.liquid
+++ b/snippets/nb-article-ctas.liquid
@@ -128,11 +128,11 @@
 -%}
 
 {%- capture _cta_card -%}
-  <div class="nb-cta">
-    <div class="nb-cta__inner">
-      <h3 class="nb-cta__title">{{ heading }}</h3>
-      <p class="nb-cta__body">{{ body }}{% if nuance != '' %} <span class="nb-cta__nuance">{{ nuance }}</span>{% endif %}</p>
-      <a class="nb-cta__btn" href="{{ url }}">{{ button }}</a>
+  <div class="nb-cta-panel">
+    <div class="nb-cta-panel__inner">
+      <h3 class="nb-cta-panel__title">{{ heading }}</h3>
+      <p class="nb-cta-panel__body">{{ body }}{% if nuance != '' %} <span class="nb-cta-panel__nuance">{{ nuance }}</span>{% endif %}</p>
+      <a class="nb-cta-panel__btn" href="{{ url }}">{{ button }}</a>
     </div>
   </div>
 {%- endcapture -%}


### PR DESCRIPTION
## Summary
- rename the article CTA card block and element classes to nb-cta-panel* to avoid sharing the global nb-cta button styles
- update the CTA snippet markup to use the new class names so only the card keeps the mint background

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3048f4254833193be2d56d94de67b