### PR TITLE
Adjust CTA snippet case formatting

### DIFF
--- a/snippets/nb-article-ctas.liquid
+++ b/snippets/nb-article-ctas.liquid
@@ -11,35 +11,27 @@
     case category
       when "Men’s Work"
         assign cat_primary = 'call'
-
         assign cat_secondary = 'leadmagnet'
       when "Relationships"
         assign cat_primary = 'leadmagnet'
-
         assign cat_secondary = 'call'
       when "Emotional Intelligence"
         assign cat_primary = 'quiz'
-
         assign cat_secondary = 'leadmagnet'
       when "Leadership"
         assign cat_primary = 'call'
-
         assign cat_secondary = 'quiz'
       when "Embodiment"
         assign cat_primary = 'leadmagnet'
-
         assign cat_secondary = 'call'
       when "Sexuality"
         assign cat_primary = 'quiz'
-
         assign cat_secondary = 'leadmagnet'
       when "Self-Discovery"
         assign cat_primary = 'quiz'
-
         assign cat_secondary = 'call'
       else
         assign cat_primary = 'leadmagnet'
-
         assign cat_secondary = 'call'
     endcase
   endif
@@ -132,27 +124,18 @@
     case primary_type
       when 'call'
         assign heading = copy_heading_call
-
         assign body = copy_body_call
-
         assign button = copy_button_call
-
         assign url = url_primary
       when 'quiz'
         assign heading = copy_heading_quiz
-
         assign body = copy_body_quiz
-
         assign button = copy_button_quiz
-
         assign url = url_primary
       else
         assign heading = copy_heading_leadmagnet
-
         assign body = copy_body_leadmagnet
-
         assign button = copy_button_leadmagnet
-
         assign url = url_primary
     endcase
   -%}
@@ -171,27 +154,18 @@
     case secondary_type
       when 'call'
         assign heading = copy_heading_call
-
         assign body = copy_body_call
-
         assign button = copy_button_call
-
         assign url = url_secondary
       when 'quiz'
         assign heading = copy_heading_quiz
-
         assign body = copy_body_quiz
-
         assign button = copy_button_quiz
-
         assign url = url_secondary
       else
         assign heading = copy_heading_leadmagnet
-
         assign body = copy_body_leadmagnet
-
         assign button = copy_button_leadmagnet
-
         assign url = url_secondary
     endcase
   -%}


### PR DESCRIPTION
## Summary
- standardize Liquid case statement formatting in `nb-article-ctas` so each `when`/`else` condition is on its own line
- keep associated assignments on the following lines to satisfy Liquid validation expectations

## Testing
- theme check snippets/nb-article-ctas.liquid *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d307f3cc6c8331873310fed5249964