### PR TITLE
Handle blank blog post cards gracefully

### DIFF
--- a/snippets/blog-post-card.liquid
+++ b/snippets/blog-post-card.liquid
@@ -1,9 +1,11 @@
 {%- liquid
   assign card_article = article
   assign card_alignment = alignment | default: 'left'
-  assign render_card = card_article != blank
-
-  if render_card
+-%}
+{%- if card_article == blank -%}
+  {%- comment -%}No article to render{%- endcomment -%}
+{%- else -%}
+  {%- liquid
     assign cat = card_article.metafields.custom.primary_category | default: ''
     assign topics_metafield = card_article.metafields.custom.subtopics
     assign topics = ''
@@ -60,9 +62,7 @@
     endif
 
     assign nb_related_post_card_css = nb_related_post_card_css | default: ''
-  endif
--%}
-{%- if render_card -%}
+  -%}
   {%- if nb_related_post_card_css == '' -%}
     {%- assign nb_related_post_card_css = 'set' -%}
     <style>


### PR DESCRIPTION
## Summary
- add an early guard to skip rendering when no article is provided to the blog post card snippet
- nest the remaining setup logic under the populated-article branch and remove the redundant render flag wrapper

## Testing
- theme-check snippets/blog-post-card.liquid *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d30b7fc2a88331abbcfaf9d16838c8