### PR TITLE
CTAs: 2-column luxe layout, compact proportions, type-aware buttons

### DIFF
--- a/assets/nb-blog-cta.css
+++ b/assets/nb-blog-cta.css
@@ -5,12 +5,14 @@
   --nb-cta-radius-lg: 24px;
   --nb-cta-radius-md: 14px;
   --nb-cta-shadow-lg: 0 32px 92px rgba(15, 91, 98, 0.18);
-  --nb-cta-shadow-md: 0 20px 52px rgba(15, 91, 98, 0.14);
-  --nb-cta-shadow-sm: 0 16px 40px rgba(28, 41, 46, 0.12);
+  --nb-cta-shadow-mid: 0 22px 56px rgba(16, 99, 108, 0.18), 0 10px 26px rgba(31, 64, 73, 0.14);
+  --nb-cta-shadow-end: 0 18px 44px rgba(31, 64, 73, 0.12), 0 6px 18px rgba(31, 64, 73, 0.08);
   --nb-cta-card-max-width: 640px;
   --nb-cta-card-padding-y: 16px;
   --nb-cta-card-padding-x: 18px;
   --nb-cta-card-gap: 14px;
+  --nb-cta-card-sheen: linear-gradient(180deg, rgba(255, 255, 255, 0.02) 0%, rgba(255, 255, 255, 0) 55%);
+  --nb-cta-body-measure: 58ch;
   --nb-cta-btn-min-height: 48px;
   --nb-cta-btn-padding-y: 14px;
   --nb-cta-btn-padding-x: 22px;
@@ -34,7 +36,7 @@
   width: min(100%, var(--nb-cta-card-max-width, 640px));
   border-radius: var(--nb-cta-radius-md);
   background: var(--nb-cta-mid-bg);
-  box-shadow: var(--nb-cta-shadow-md);
+  box-shadow: var(--nb-cta-shadow-mid);
   overflow: hidden;
   color: var(--nb-cta-ink);
 }
@@ -44,32 +46,45 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  opacity: 0;
-  background: radial-gradient(120% 140% at 12% 8%, rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0));
+  background: var(--nb-cta-card-sheen), radial-gradient(120% 140% at 12% 8%, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0));
   transition: opacity 0.3s ease;
 }
 
 .nb-cta-panel__inner {
   position: relative;
   padding: var(--nb-cta-card-padding-y) var(--nb-cta-card-padding-x);
-  display: flex;
-  flex-direction: column;
+}
+
+.nb-cta-panel__grid {
+  display: grid;
   gap: var(--nb-cta-card-gap);
 }
 
+.nb-cta-panel__content {
+  display: flex;
+  flex-direction: column;
+}
+
+.nb-cta-panel__action {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+}
+
 .nb-cta-panel__title {
-  margin: 0;
+  margin: 0 0 0.25em;
   font-size: clamp(1.125rem, 2.6vw, 1.375rem);
   font-weight: 700;
   letter-spacing: -0.01em;
-  line-height: 1.3;
+  line-height: 1.22;
   color: inherit;
 }
 
 .nb-cta-panel__body {
   margin: 0;
-  color: var(--nb-cta-ink-soft);
-  line-height: 1.55;
+  max-width: var(--nb-cta-body-measure);
+  color: color-mix(in srgb, var(--nb-cta-ink), transparent 10%);
+  line-height: 1.5;
   font-size: clamp(1rem, 2.1vw, 1.1rem);
 }
 
@@ -82,7 +97,6 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  align-self: flex-start;
   padding: var(--nb-cta-btn-padding-y) var(--nb-cta-btn-padding-x);
   min-height: var(--nb-cta-btn-min-height);
   border-radius: var(--nb-cta-btn-radius);
@@ -164,7 +178,7 @@
 .nb-cta-wrap--mid .nb-cta-panel {
   background: var(--nb-cta-mid-bg);
   border-radius: var(--nb-cta-radius-md);
-  box-shadow: var(--nb-cta-shadow-md);
+  box-shadow: var(--nb-cta-shadow-mid);
 }
 
 .nb-cta-wrap--end {
@@ -174,7 +188,7 @@
 .nb-cta-wrap--end .nb-cta-panel {
   background: var(--nb-cta-end-bg);
   border-radius: var(--nb-cta-radius-md);
-  box-shadow: var(--nb-cta-shadow-sm);
+  box-shadow: var(--nb-cta-shadow-end);
 }
 
 .nb-cta-wrap--end .nb-cta-panel__btn.nb-btn--noncall {
@@ -192,6 +206,16 @@
   box-shadow: 0 16px 32px color-mix(in srgb, var(--nb-cta-color-teal), transparent 64%);
 }
 
+@media (max-width: 63.99em) {
+  .nb-cta-panel__action {
+    width: 100%;
+  }
+
+  .nb-cta-panel__btn {
+    width: 100%;
+  }
+}
+
 @media (max-width: 740px) {
   .nb-cta-wrap {
     margin: clamp(28px, 8vw, 48px) 0;
@@ -201,13 +225,21 @@
     padding: calc(var(--nb-cta-card-padding-y) * 0.9) calc(var(--nb-cta-card-padding-x) * 0.9);
   }
 
-  .nb-cta-panel__btn {
-    width: 100%;
-    text-align: center;
-  }
-
   .nb-cta-wrap--top .nb-cta-panel__btn {
     width: 100%;
+  }
+}
+
+@media (min-width: 64em) {
+  .nb-cta-wrap--mid .nb-cta-panel__grid,
+  .nb-cta-wrap--end .nb-cta-panel__grid {
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    align-items: center;
+  }
+
+  .nb-cta-wrap--mid .nb-cta-panel__action,
+  .nb-cta-wrap--end .nb-cta-panel__action {
+    justify-content: flex-end;
   }
 }
 

--- a/snippets/nb-article-ctas.liquid
+++ b/snippets/nb-article-ctas.liquid
@@ -184,9 +184,15 @@
 {%- capture _cta_card -%}
   <div class="nb-cta-panel">
     <div class="nb-cta-panel__inner">
-      <h3 class="nb-cta-panel__title">{{ heading }}</h3>
-      <p class="nb-cta-panel__body">{{ body }}{% if nuance != '' %} <span class="nb-cta-panel__nuance">{{ nuance }}</span>{% endif %}</p>
-      <a class="nb-cta-panel__btn{{ btn_modifier }}" data-cta-type="{{ cta_type }}" href="{{ url }}">{{ button }}</a>
+      <div class="nb-cta-panel__grid">
+        <div class="nb-cta-panel__content">
+          <h3 class="nb-cta-panel__title">{{ heading }}</h3>
+          <p class="nb-cta-panel__body">{{ body }}{% if nuance != '' %} <span class="nb-cta-panel__nuance">{{ nuance }}</span>{% endif %}</p>
+        </div>
+        <div class="nb-cta-panel__action">
+          <a class="nb-cta-panel__btn{{ btn_modifier }}" data-cta-type="{{ cta_type }}" href="{{ url }}">{{ button }}</a>
+        </div>
+      </div>
     </div>
   </div>
 {%- endcapture -%}


### PR DESCRIPTION
## Summary
* Adds 2-column layout on desktop (copy left, button right + centered), stacks on mobile.
* Constrains body text measure to ~55–70 CPL for readability.
* Unifies compact footprint (radius, padding, button sizing) with inline reference.
* Type-aware button palette (Chocolate=Call, Teal=Non-Call); subtle elevation hierarchy (mid > end).
* No logic or metafield changes.

------
https://chatgpt.com/codex/tasks/task_e_68d31a573ea883319ab765dc20b14700