### PR TITLE
Adjust CTA grid for long button labels

### DIFF
--- a/assets/nb-blog-cta.css
+++ b/assets/nb-blog-cta.css
@@ -233,13 +233,17 @@
 @media (min-width: 64em) {
   .nb-cta-wrap--mid .nb-cta-panel__grid,
   .nb-cta-wrap--end .nb-cta-panel__grid {
-    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    grid-template-columns: minmax(0, 2fr) max-content;
     align-items: center;
   }
 
   .nb-cta-wrap--mid .nb-cta-panel__action,
   .nb-cta-wrap--end .nb-cta-panel__action {
     justify-content: flex-end;
+  }
+
+  .nb-cta-panel__btn {
+    white-space: nowrap;
   }
 }
 


### PR DESCRIPTION
## Summary
- size the desktop CTA grid action column to its content to accommodate longer button labels
- prevent CTA buttons from wrapping text on wide breakpoints for better readability

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d31d40e42c83318387ffdb643f3404