### PR TITLE
Related posts: show full titles; keep excerpt clamped

### DIFF
--- a/assets/nb-related-cards.css
+++ b/assets/nb-related-cards.css
@@ -16,7 +16,7 @@
 }
 
 .nb-related__item--lux {
-  height: 100%;
+  height: auto;
 }
 
 @media (min-width: 40rem) {
@@ -87,12 +87,6 @@
   line-height: 1.2;
   letter-spacing: -0.01em;
   color: rgb(var(--color-foreground-rgb) / var(--opacity-90));
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .nb-related-card__meta {


### PR DESCRIPTION
## Summary
- Removes title truncation/ellipsis and fixed heights on titles.
- Keeps excerpt at 2 lines; grid remains responsive (3/2/1).
- Improves comprehension by exposing complete titles (per Baymard). ([Baymard Institute](https://baymard.com/blog/product-page-suggestions-information?utm_source=chatgpt.com))

------
https://chatgpt.com/codex/tasks/task_e_68d32315ced08331a580f436c4d9c16b