### PR TITLE
Remove redundant related post card styles

### DIFF
--- a/sections/main-blog-post.liquid
+++ b/sections/main-blog-post.liquid
@@ -253,11 +253,6 @@
   .nb-related__grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:16px}
   @media (max-width:900px){ .nb-related__grid{grid-template-columns:1fr 1fr} }
   @media (max-width:620px){ .nb-related__grid{grid-template-columns:1fr} }
-  .nb-related__card{background:#fff;border:1px solid #e8ecef;border-radius:14px;overflow:hidden;box-shadow:0 8px 18px rgba(0,0,0,.06)}
-  .nb-related__img{display:block;width:100%;height:auto;aspect-ratio:16/9;object-fit:cover}
-  .nb-related__link{display:block;text-decoration:none;color:inherit;padding:12px 14px}
-  .nb-related__title{margin:8px 0 6px;font-weight:750}
-  .nb-related__meta{margin:0;color:#6b7a80;font-size:.9rem}
 
   /* Existing comment styles retained */
   .blog-post-comments-container { width:100%; max-width:var(--normal-content-width); margin:0 auto; }


### PR DESCRIPTION
## Summary
- remove redundant related post card styling from the main blog post section stylesheet so shared nb-related rules remain while card details rely on nb-related-cards.css

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d327151bc883318c66f370eef7d60d