### PR TITLE
Remove unused blog tag and reading-time styles

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -5332,24 +5332,10 @@ body.nb-typography{
 .nb-blog-hero__title{margin:0 0 6px}
 .nb-blog-hero__dek{color:var(--nb-muted,#324247);margin:0 0 12px}
 
-/* Tag chips (optional) */
-.nb-tagbar{ margin: 6px 0 16px; }
-.nb-tagbar__list{ display:flex; flex-wrap:wrap; gap:10px; margin:0; padding:0; list-style:none; }
-.nb-tagbar__chip{ display:inline-flex; align-items:center; gap:8px; padding:.5rem .8rem;
-  background:#fff; border:1px solid rgba(0,0,0,.06); border-radius:999px;
-  box-shadow:0 6px 16px rgba(0,0,0,.05); text-decoration:none; color:var(--nb-muted,#324247);
-  font-weight:600;
-}
-.nb-tagbar__chip.is-active{ border-color: var(--nb-chocolate,#C86B2A); color:#000; }
-
 /* temp: hide footer products block until offer is ready */
 .footer [data-footer-products],
 .footer a[href*="/products"],
 .footer a[href*="/collections"] { display: none !important; }
-
-/* Blog meta: reading time separator + tone */
-.rt-sep{ opacity:.45; margin:0 .35rem; }
-.rt{ opacity:.75; }
 
 /* Subtle hairline above footer utilities */
 .footer .footer-utilities{


### PR DESCRIPTION
## Summary
- delete obsolete tag bar and reading-time CSS rules from assets/base.css since the markup no longer uses them

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d32803f0ec833192ac1d90c33f3f38