### PR TITLE
⬇️ Codex prompt — “LM widget: add parallel Mailchimp submit (same pattern as Contact/Quiz)”

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -2329,6 +2329,18 @@
         "id": "lm_widget_label",
         "label": "Lead magnet button label",
         "default": "Get my free guide"
+      },
+      {
+        "type": "checkbox",
+        "id": "lm_mc_parallel",
+        "label": "Also send to Mailchimp (parallel)",
+        "default": true
+      },
+      {
+        "type": "text",
+        "id": "lm_mc_action",
+        "label": "Mailchimp form action URL",
+        "default": ""
       }
     ]
   }

--- a/snippets/nb-lm-widget.liquid
+++ b/snippets/nb-lm-widget.liquid
@@ -2,7 +2,7 @@
   {{ settings.lm_widget_label | default: 'Get my free guide' }}
 </button>
 
-<div class="nb-lm" id="nb-lm-modal" data-nb-lm-widget hidden>
+<div class="nb-lm" id="nb-lm-modal" data-nb-lm-widget data-mc-parallel="{{ settings.lm_mc_parallel }}" data-mc-action="{{ settings.lm_mc_action | escape }}" hidden>
   <div class="nb-lm__backdrop" data-nb-lm-close aria-hidden="true"></div>
   <div class="nb-lm__dialog" role="dialog" aria-modal="true" aria-labelledby="nb-lm-title" aria-describedby="nb-lm-description" aria-hidden="true" data-nb-lm-dialog tabindex="-1">
     <button type="button" class="nb-lm__close" data-nb-lm-close aria-label="Close lead magnet"></button>


### PR DESCRIPTION
## Summary
- add Mailchimp parallel delivery controls to the Lead magnet theme settings
- expose Mailchimp settings to the widget markup for runtime access
- trigger a non-blocking Mailchimp subscribe POST after successful Shopify submissions

## Testing
- not run (not requested)

## QA Checklist
- [ ] Theme Editor shows Lead magnet settings: label, Also send to Mailchimp (parallel), and Mailchimp form action URL.
- [ ] Submitting the widget posts to /contact (AJAX), shows success panel (with Open the guide → /dl/connection-guide), and then dispatches a list-manage.com/subscribe/post request in Network (no-cors).
- [ ] A new Customer appears in Shopify with Subscribed status and tags newsletter, leadmagnet:connections_guide, source:widget (+ UTMs if present).
- [ ] GA4 events: lead_submit on click, generate_lead on success; relay fires asset_open.
- [ ] No legacy Mailchimp popup script loads.

------
https://chatgpt.com/codex/tasks/task_e_68d41f6175508331b205d4138fb83745