### PR TITLE
Configure LM copy and challenge-safe submit

### DIFF
--- a/assets/nb-lm-widget.js
+++ b/assets/nb-lm-widget.js
@@ -490,7 +490,7 @@
     }
 
     var okish = res && (res.ok || res.status === 200 || res.status === 201 || res.status === 204 ||
-      res.status === 302 || res.status === 303 || res.redirected === true);
+      res.status === 302 || res.status === 303);
     var looksChallenge = (finalURL && /\/challenge/i.test(finalURL)) || /h-captcha|g-recaptcha/i.test(bodySnippet);
 
     if (res && okish && !looksChallenge) {
@@ -501,25 +501,24 @@
     }
 
     var networkError = !res;
-    var shouldFallback = networkError || (res && (!okish || looksChallenge));
-    var fallbackOk = false;
+    var fallbackAttempted = false;
 
-    if (shouldFallback) {
-      if (!networkError) {
-        markPendingSuccess();
-      }
-      fallbackOk = nativeFallbackSubmit(lastSubmitContext);
-      if (fallbackOk) {
+    if (looksChallenge) {
+      markPendingSuccess();
+      fallbackAttempted = true;
+      if (nativeFallbackSubmit(lastSubmitContext)) {
         return;
       }
     }
 
-    if (networkError) {
+    if (networkError || !okish || fallbackAttempted) {
       showInlineError('We hit a snag—please try again.');
       var errorFocus = getFieldInput('email');
       if (errorFocus && typeof errorFocus.focus === 'function') {
         errorFocus.focus();
       }
+      enableSubmitButton(submitBtn);
+      return;
     }
 
     enableSubmitButton(submitBtn);

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -2329,6 +2329,30 @@
         "id": "lm_widget_label",
         "label": "Lead magnet button label",
         "default": "Get my free guide"
+      },
+      {
+        "type": "text",
+        "id": "lm_title",
+        "label": "LM modal headline",
+        "default": "Get the Connection Guide"
+      },
+      {
+        "type": "textarea",
+        "id": "lm_subhead",
+        "label": "LM modal subheading",
+        "default": "Pop your details below and I’ll send the Connections Guide straight to your inbox."
+      },
+      {
+        "type": "text",
+        "id": "lm_success_title",
+        "label": "LM success headline",
+        "default": "You’re in. Here’s your guide."
+      },
+      {
+        "type": "textarea",
+        "id": "lm_success_body",
+        "label": "LM success body",
+        "default": "Open your copy of the Connections Guide — we’ve also emailed it to you so you can revisit it any time."
       }
     ]
   }

--- a/snippets/nb-lm-widget.liquid
+++ b/snippets/nb-lm-widget.liquid
@@ -9,8 +9,8 @@
     <div class="nb-lm__content">
       <header class="nb-lm__header">
         <p class="nb-eyebrow">Free guide</p>
-        <h2 class="nb-lm__title" id="nb-lm-title">5 shifts to help your teen feel truly seen</h2>
-        <p class="nb-lm__dek" id="nb-lm-description">Pop your details below and I’ll send the Connections Guide straight to your inbox.</p>
+        <h2 class="nb-lm__title" id="nb-lm-title">{{ settings.lm_title | default: 'Get the Connection Guide' }}</h2>
+        <p class="nb-lm__dek" id="nb-lm-description">{{ settings.lm_subhead | default: 'Pop your details below and I’ll send the Connections Guide straight to your inbox.' }}</p>
       </header>
       <form class="nb-lm__form" id="nb-lm-form" data-nb-lm-form method="post" novalidate>
         <input type="hidden" name="form_type" value="customer">
@@ -40,29 +40,14 @@
         <div class="nb-lm__message" data-nb-lm-message role="status" aria-live="polite"></div>
       </form>
       <div class="nb-lm__success" data-nb-lm-success hidden>
-        <h3 class="nb-lm__success-title">You’re in. Here’s your guide.</h3>
-        <p class="nb-lm__success-copy">Open your copy of the Connections Guide — we’ve also emailed it to you so you can revisit it any time.</p>
+        <h3 class="nb-lm__success-title">{{ settings.lm_success_title | default: "You’re in. Here’s your guide." }}</h3>
+        <p class="nb-lm__success-copy">{{ settings.lm_success_body | default: "Open your copy of the Connections Guide — we’ve also emailed it to you so you can revisit it any time." }}</p>
         <div class="nb-lm__success-actions">
           <a class="nb-cta nb-cta--md nb-cta--teal" href="/dl/connection-guide" rel="noopener">Open the guide</a>
           <a class="nb-link nb-link--cta" href="/pages/discovery-call">Book a discovery call</a>
         </div>
       </div>
-      <div aria-hidden="true" style="position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;">
-        <form
-          action="https://life.us4.list-manage.com/subscribe/post?u=41960bde0a78c656a84bb759b&amp;id=d3d64ba831"
-          method="post"
-          target="nb-lm-mc-target"
-          id="nb-lm-mc"
-          novalidate
-        >
-          <input type="text" name="FNAME" id="nb-lm-mc-fname">
-          <input type="text" name="LNAME" id="nb-lm-mc-lname">
-          <input type="email" name="EMAIL" id="nb-lm-mc-email">
-          <input type="hidden" name="group[78632][1]" value="1">
-          <input type="submit" value="Subscribe">
-        </form>
-        <iframe name="nb-lm-mc-target" id="nb-lm-mc-target" title="Mailchimp submit" hidden></iframe>
-      </div>
+      {% render 'nb-mc-mirror-lm' %}
     </div>
   </div>
 </div>

--- a/snippets/nb-mc-mirror-lm.liquid
+++ b/snippets/nb-mc-mirror-lm.liquid
@@ -1,0 +1,19 @@
+<div aria-hidden="true" style="position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;">
+  <!-- LM mirror only — do not include quiz/contact merge fields. -->
+  <form
+    action="https://life.us4.list-manage.com/subscribe/post?u=41960bde0a78c656a84bb759b&amp;id=d3d64ba831"
+    method="post"
+    target="nb-lm-mc-target"
+    id="nb-lm-mc"
+    novalidate
+  >
+    <input type="hidden" name="u" value="41960bde0a78c656a84bb759b">
+    <input type="hidden" name="id" value="d3d64ba831">
+    <input type="email" name="EMAIL" id="nb-lm-mc-email">
+    <input type="text" name="FNAME" id="nb-lm-mc-fname">
+    <input type="text" name="LNAME" id="nb-lm-mc-lname">
+    <input type="hidden" name="tags" value="leadmagnet:connections_guide,source:widget">
+    <input type="submit" value="Subscribe">
+  </form>
+  <iframe name="nb-lm-mc-target" id="nb-lm-mc-target" title="Mailchimp submit" hidden></iframe>
+</div>


### PR DESCRIPTION
## Summary
- add theme settings to control the lead magnet modal copy and render those values in the widget
- introduce a dedicated Mailchimp mirror snippet for the lead magnet without quiz/contact merge fields
- harden the lead magnet submit flow to fall back to Shopify challenges before showing success and preserve analytics

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d46908be8c8331aed96c08a66129bd