### PR TITLE
Refine lead magnet submit flow

### DIFF
--- a/assets/nb-lm-widget.js
+++ b/assets/nb-lm-widget.js
@@ -65,21 +65,6 @@
   }
 
 
-  function markPendingSuccess(){
-    safeStorage(function(){ localStorage.setItem(STORAGE_PENDING_SUCCESS, '1'); });
-  }
-
-
-  function consumePendingSuccess(){
-    var pending = safeStorage(function(){ return localStorage.getItem(STORAGE_PENDING_SUCCESS); });
-    if (pending === '1') {
-      safeStorage(function(){ localStorage.removeItem(STORAGE_PENDING_SUCCESS); });
-      return true;
-    }
-    return false;
-  }
-
-
   function withinCooldown(){
     var ts = safeStorage(function(){ return localStorage.getItem(STORAGE_COOLDOWN); });
     if (!ts) return false;
@@ -242,19 +227,14 @@
 
   }
 
-  function submitMailchimpMirror(first, last, email){
+  function primeMailchimpMirror(first, last, email){
     if (!mailchimpForm) return;
     try {
       if (mailchimpFields.first) mailchimpFields.first.value = first || '';
       if (mailchimpFields.last) mailchimpFields.last.value = last || '';
       if (mailchimpFields.email) mailchimpFields.email.value = email || '';
-      if (mailchimpForm.requestSubmit) {
-        mailchimpForm.requestSubmit();
-      } else {
-        mailchimpForm.submit();
-      }
     } catch (err) {
-      console.warn('NB LM: Mailchimp mirror submit skipped', err);
+      console.warn('NB LM: Mailchimp mirror sync skipped', err);
     }
   }
 
@@ -321,11 +301,6 @@
     return buildTags(utms).join(',');
   }
 
-  function formRootUrl(){
-    var widgetEl = widget || (form && form.closest('[data-nb-lm-widget]'));
-    return (widgetEl && widgetEl.getAttribute('data-root-url')) || '/';
-  }
-
   function clearFieldErrors(){
     if (!form) return;
     var fields = form.querySelectorAll('[data-nb-lm-field]');
@@ -360,7 +335,7 @@
     return input || null;
   }
 
-  async function onLmSubmit(evt){
+  function onLmSubmit(evt){
     if (!form) return;
     if (evt && typeof evt.preventDefault === 'function') evt.preventDefault();
     if (evt && typeof evt.stopPropagation === 'function') evt.stopPropagation();
@@ -414,7 +389,7 @@
     var utms = collectUtmsForSubmit();
     var tags = makeTagString(utms);
     var widgetEl = widget || (form && form.closest('[data-nb-lm-widget]'));
-    var rootUrl = (widgetEl && widgetEl.getAttribute('data-root-url')) || formRootUrl() || '/';
+    var rootUrl = (widgetEl && widgetEl.getAttribute('data-root-url')) || '/';
 
     ensureHidden('form_type', 'customer');
     ensureHidden('utf8', '\u2713');
@@ -423,16 +398,19 @@
     ensureHidden('contact[last_name]', last);
     ensureHidden('contact[tags]', tags);
 
-    submitMailchimpMirror(first, last, email);
+    primeMailchimpMirror(first, last, email);
 
-    markPendingSuccess();
+    try { localStorage.setItem(STORAGE_PENDING_SUCCESS, '1'); } catch (_) {}
+
+    var mc = mailchimpForm || (widgetEl && widgetEl.querySelector('[data-nb-mc-mirror="lm"]'));
+    try { if (mc && typeof mc.submit === 'function') mc.submit(); } catch (_) {}
 
     form.setAttribute('action', rootUrl);
     form.method = 'POST';
     form.enctype = 'application/x-www-form-urlencoded';
     form.noValidate = true;
 
-    console.info('NB LM: native Shopify submit');
+    console.info('NB LM: native-submit launched');
 
     try {
       form.submit();
@@ -572,7 +550,7 @@
     successView = widget && widget.querySelector('[data-nb-lm-success]');
     messageRegion = widget && widget.querySelector('[data-nb-lm-message]');
     pill = document.querySelector('[data-nb-lm-pill]');
-    mailchimpForm = widget && widget.querySelector('#nb-lm-mc');
+    mailchimpForm = widget && widget.querySelector('[data-nb-mc-mirror="lm"]');
     if (mailchimpForm) {
       mailchimpFields.first = mailchimpForm.querySelector('#nb-lm-mc-fname');
       mailchimpFields.last = mailchimpForm.querySelector('#nb-lm-mc-lname');
@@ -582,7 +560,13 @@
     if (!widget || !form) return;
 
     honeypot = ensureHoneypot();
-    var shouldResumeSuccess = consumePendingSuccess();
+    var shouldResumeSuccess = false;
+    try {
+      if (localStorage.getItem(STORAGE_PENDING_SUCCESS) === '1') {
+        localStorage.removeItem(STORAGE_PENDING_SUCCESS);
+        shouldResumeSuccess = true;
+      }
+    } catch (_) {}
 
     if (successView) {
       var successLink = successView.querySelector('a.nb-cta');
@@ -609,11 +593,7 @@
 
     if (shouldResumeSuccess) {
       openLeadMagnetModal({ showSuccess: true });
-      try {
-        if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
-          window.gtag('event', 'generate_lead', { method: 'lead_magnet_widget' });
-        }
-      } catch (err) {}
+      try { window.gtag('event', 'generate_lead', { method: 'lead_magnet_widget' }); } catch (_) {}
       setSubmitting(false);
     }
   }

--- a/snippets/nb-mc-mirror-lm.liquid
+++ b/snippets/nb-mc-mirror-lm.liquid
@@ -5,6 +5,7 @@
     method="post"
     target="nb-lm-mc-target"
     id="nb-lm-mc"
+    data-nb-mc-mirror="lm"
     novalidate
   >
     <input type="hidden" name="u" value="41960bde0a78c656a84bb759b">


### PR DESCRIPTION
## Summary
- force the lead magnet form to submit natively to Shopify while preparing hidden fields, mirroring Mailchimp fire-and-forget, and resuming success after return
- tag the hidden Mailchimp mirror form so the widget script can locate it reliably

## Testing
- Not run (not requested)

## QA Checklist
* [ ] On submit, console logs `NB LM: native-submit launched`; the page navigates (Shopify may show challenge).
* [ ] After returning, the modal **auto-opens in success** (using `nb_lm_pending_success`).
* [ ] **Shopify Customers** shows the new contact as **Subscribed** with tags `newsletter`, `leadmagnet:connections_guide`, `source:widget` (+ UTMs).
* [ ] **Mailchimp** still receives the contact (mirror submit) but does **not** control success timing.
* [ ] GA4 events: `lead_submit` on submit; `generate_lead` on resume/success.


------
https://chatgpt.com/codex/tasks/task_e_68d55753ae8083318a25950ae2e25b6b