### PR TITLE
Fix lead magnet success detection

### DIFF
--- a/assets/nb-lm-widget.js
+++ b/assets/nb-lm-widget.js
@@ -238,6 +238,17 @@
     }
   }
 
+  function hasShopifySuccess(){
+    try {
+      var qs = new URLSearchParams(window.location.search || '');
+      if (qs.get('contact_posted') === 'true') return true;
+      if (qs.get('customer_posted') === 'true') return true;
+      return false;
+    } catch (_) {
+      return false;
+    }
+  }
+
   function buildTags(utms){
     var tags = BASE_TAGS.slice();
     if (utms) {
@@ -337,27 +348,26 @@
 
   function onLmSubmit(evt){
     if (!form) return;
-    if (evt && typeof evt.preventDefault === 'function') evt.preventDefault();
-    if (evt && typeof evt.stopPropagation === 'function') evt.stopPropagation();
-    if (evt && typeof evt.stopImmediatePropagation === 'function') evt.stopImmediatePropagation();
+
+    var shouldPrevent = false;
 
     if (honeypot && honeypot.value) {
-      return;
+      shouldPrevent = true;
     }
 
     clearFieldErrors();
     showMessage('info', '');
 
     var submitBtn = getSubmitButton();
-    if (submitBtn && submitBtn.dataset.nbLmSubmitting === 'true') {
-      return;
+    if (!shouldPrevent && submitBtn && submitBtn.dataset.nbLmSubmitting === 'true') {
+      shouldPrevent = true;
     }
 
     var first = getFirstName();
     var last = getLastName();
     var email = getEmail();
 
-    var hasErrors = false;
+    var hasErrors = shouldPrevent;
     var focusTarget = null;
 
     if (!first) {
@@ -376,9 +386,19 @@
     }
 
     if (hasErrors) {
+      shouldPrevent = true;
       if (focusTarget && typeof focusTarget.focus === 'function') {
         focusTarget.focus();
       }
+    }
+
+    if (evt && shouldPrevent) {
+      if (typeof evt.preventDefault === 'function') evt.preventDefault();
+      if (typeof evt.stopPropagation === 'function') evt.stopPropagation();
+      if (typeof evt.stopImmediatePropagation === 'function') evt.stopImmediatePropagation();
+    }
+
+    if (shouldPrevent) {
       return;
     }
 
@@ -413,21 +433,7 @@
     form.enctype = 'application/x-www-form-urlencoded';
     form.noValidate = true;
 
-    console.info('NB LM: native-submit launched');
-
-    try {
-      form.submit();
-      return;
-    } catch (err) {
-      console.error('NB LM: native submit failed', err);
-      safeStorage(function(){ localStorage.removeItem(STORAGE_PENDING_SUCCESS); });
-      showInlineError('We hit a snag—please try again.');
-      setSubmitting(false);
-      var errorFocus = getFieldInput('email');
-      if (errorFocus && typeof errorFocus.focus === 'function') {
-        errorFocus.focus();
-      }
-    }
+    console.info('NB LM: handing submit to Shopify');
   }
 
   function handleKeydown(evt){
@@ -589,13 +595,22 @@
     bindEvents();
 
     (function resumeLmSuccess(){
-      if (localStorage.getItem(STORAGE_PENDING_SUCCESS) === '1') {
-        localStorage.removeItem(STORAGE_PENDING_SUCCESS);
+      if (localStorage.getItem(STORAGE_PENDING_SUCCESS) !== '1') return;
+
+      localStorage.removeItem(STORAGE_PENDING_SUCCESS);
+
+      if (hasShopifySuccess()) {
         openLeadMagnetModal({ showSuccess: true });
         try { window.gtag('event', 'generate_lead', { method: 'lead_magnet_widget' }); } catch (_) {}
         setSubmitting(false);
         console.info('NB LM: resumed success after Shopify round-trip');
+        return;
       }
+
+      setSubmitting(false);
+      openLeadMagnetModal({ showSuccess: false });
+      showInlineError('We couldn\'t confirm your signup. Please try again.');
+      console.warn('NB LM: Shopify did not report success.');
     })();
   }
 


### PR DESCRIPTION
## Summary
- add detection for Shopify success parameters before showing the lead magnet success panel
- surface an inline error if Shopify does not confirm the signup so the user can retry
- allow Shopify to process the form submission directly so captcha and customer creation can complete

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d569e1c9ec8331895b08b4c7d1e8cb