### PR TITLE
Lead magnet: restore Mailchimp popup + mute native LM (provider toggle)

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -5895,3 +5895,6 @@ body.nb-typography{
 
 .article-tags, .tag-list, .nb-article-tags { display: none !important; }
 .nb-related__grid{ display:grid; grid-template-columns:repeat(auto-fill, minmax(260px,1fr)); gap:16px; }
+
+.lm-provider-mailchimp .nb-lm-pill,
+.lm-provider-mailchimp #nb-lm-modal { display: none !important; }

--- a/assets/nb-lm-widget.js
+++ b/assets/nb-lm-widget.js
@@ -1,6 +1,13 @@
 (function(){
   'use strict';
 
+  var html = document.documentElement;
+  var provider = html.getAttribute('data-lm-provider') || 'mailchimp';
+  if (provider !== 'shopify') {
+    console.info('NB LM: native widget disabled (provider=' + provider + ')');
+    return;
+  }
+
   var RELAY_PATH = '/dl/connection-guide';
   var STORAGE_UTM = 'nb_lm_widget_utms';
   var STORAGE_COOLDOWN = 'nb_lm_widget_cooldown';

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -77,12 +77,13 @@
     "variant_button_border_width": 1,
     "variant_button_radius": 14,
     "variant_button_width": "equal-width-buttons",
+    "lm_provider": "mailchimp",
     "lm_title": "5 Shifts that create Real Connection",
     "content_for_index": [],
     "blocks": {
       "18131037017812181619": {
         "type": "shopify://apps/mailchimp-email-sms/blocks/mailchimp_for_shopify_script/e3b67dce-fd41-4b61-b3cf-961c12344cde",
-        "disabled": true,
+        "disabled": false,
         "settings": {}
       },
       "14339172867238703359": {

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -2325,6 +2325,16 @@
     "name": "Lead magnet",
     "settings": [
       {
+        "type": "select",
+        "id": "lm_provider",
+        "label": "Lead magnet provider",
+        "default": "mailchimp",
+        "options": [
+          { "value": "mailchimp", "label": "Mailchimp (popup)" },
+          { "value": "shopify",  "label": "Shopify (native)" }
+        ]
+      },
+      {
         "type": "text",
         "id": "lm_widget_label",
         "label": "Lead magnet button label",

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -1,6 +1,7 @@
 <!doctype html>
 <html
-  class="no-js{% if request.design_mode %} shopify-design-mode{% endif %}"
+  class="no-js{% if request.design_mode %} shopify-design-mode{% endif %} lm-provider-{{ settings.lm_provider }}"
+  data-lm-provider="{{ settings.lm_provider }}"
   lang="{{ request.locale.iso_code }}"
 >
   <head>
@@ -510,7 +511,9 @@ It:
   });
 })();
 </script>
-{% render 'nb-lm-widget' %}
+{% if settings.lm_provider == 'shopify' %}
+  {% render 'nb-lm-widget' %}
+{% endif %}
 {% render 'nb-sticky-cta-controller' %}
 {% render 'nb-anim-init' %}
 {% render 'nb-newsletter-proxy' %}


### PR DESCRIPTION
## Summary
- add a lead magnet provider setting to toggle between Mailchimp and Shopify experiences
- expose provider information on the root html element and conditionally render the native widget
- guard the native widget assets and styles so they only activate when Shopify is selected
- set the theme data to Mailchimp with the Mailchimp app embed enabled

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5847977e083319c99e7d7709447dc