### PR TITLE
FAB: restore mobile lift when Mailchimp widget is active

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -5000,10 +5000,10 @@ section.testimonial-section h2 , rte-formatter.spacing-style.text-block.text-blo
   .nb-fab.is-hidden{ transform: translateY(120%); opacity: 0; }
 }
 
-/* === FAB vs Mailchimp (mobile lift + left align) === */
+/* --- FAB lift defaults and positioning --- */
 :root {
   --nb-fab-gap: 16px;
-  --nb-fab-lift: 0px; /* set by JS */
+  --nb-fab-lift: 0px;
 }
 
 /* Ensure the FAB can sit above overlays */
@@ -5024,6 +5024,12 @@ section.testimonial-section h2 , rte-formatter.spacing-style.text-block.text-blo
     );
 
     transform: none; /* never centered */
+  }
+}
+/* Mobile: when Mailchimp provider is active, reserve safe gap even if JS hasn't measured yet */
+@media (max-width: 749px) {
+  .lm-provider-mailchimp {
+    --nb-fab-lift: 72px; /* safe default so Book-a-call clears the Mailchimp pill */
   }
 }
 /* Hide the mobile FAB on tablet/desktop */

--- a/assets/nb-fab-lift-v2.js
+++ b/assets/nb-fab-lift-v2.js
@@ -1,0 +1,82 @@
+(function () {
+  try {
+    var html = document.documentElement;
+    var provider = html.getAttribute('data-lm-provider') || 'mailchimp';
+    // Only adjust when our FAB exists
+    var fab = document.querySelector('.nb-fab');
+    if (!fab) return;
+
+    // Helper: is element visible
+    var isVisible = function(el) {
+      if (!el) return false;
+      var s = getComputedStyle(el);
+      if (s.display === 'none' || s.visibility === 'hidden' || parseFloat(s.opacity) === 0) return false;
+      var r = el.getBoundingClientRect();
+      return r.width > 0 && r.height > 0;
+    };
+
+    // Compute lift from an element (height + 12px breathing room)
+    var liftFrom = function(el) {
+      var h = el.getBoundingClientRect().height || 0;
+      return Math.max(0, Math.round(h + 12));
+    };
+
+    // Scan likely Mailchimp nodes
+    var findMailchimpNode = function() {
+      // common candidates Mailchimp injects for popup/trigger
+      var candidates = document.querySelectorAll([
+        '.mc-modal',
+        '.mc-closeModal',
+        '.mc-prompt',
+        '.mc-banner',
+        '[id^="mc-"]:not(script)',
+        '[class*="mailchimp"]',
+        '[class*="mcjs"]'
+      ].join(','));
+      for (var i=0; i<candidates.length; i++) {
+        var el = candidates[i];
+        if (!isVisible(el)) continue;
+        // Near bottom of viewport?
+        var r = el.getBoundingClientRect();
+        if (r.bottom >= (window.innerHeight - 140)) return el;
+      }
+      return null;
+    };
+
+    var applyLift = function(px) {
+      // Never lower below zero; keep CSS default as baseline
+      if (typeof px !== 'number') return;
+      html.style.setProperty('--nb-fab-lift', px + 'px');
+    };
+
+    var measure = function() {
+      // If Shopify provider, lift off native LM pill instead (if you want)
+      if (provider === 'shopify') {
+        var nativePill = document.querySelector('.nb-lm-pill');
+        if (isVisible(nativePill)) {
+          applyLift(liftFrom(nativePill));
+          return;
+        }
+        applyLift(0);
+        return;
+      }
+
+      // Provider = Mailchimp → try to measure
+      var mc = findMailchimpNode();
+      if (mc) {
+        applyLift(liftFrom(mc));
+      } else {
+        // leave CSS default (72px via CSS on mobile) as a safe fallback
+      }
+    };
+
+    // Run now and when layout changes
+    measure();
+    window.addEventListener('resize', measure, { passive: true });
+    // Watch DOM for Mailchimp nodes arriving
+    var mo = new MutationObserver(function() { measure(); });
+    mo.observe(document.documentElement, { subtree: true, childList: true });
+  } catch (e) {
+    console && console.warn && console.warn('NB FAB lift init failed', e);
+  }
+})();

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -1,9 +1,5 @@
 <!doctype html>
-<html
-  class="no-js{% if request.design_mode %} shopify-design-mode{% endif %} lm-provider-{{ settings.lm_provider }}"
-  data-lm-provider="{{ settings.lm_provider }}"
-  lang="{{ request.locale.iso_code }}"
->
+<html class="no-js{% if request.design_mode %} shopify-design-mode{% endif %} lm-provider-{{ settings.lm_provider }}" data-lm-provider="{{ settings.lm_provider }}" lang="{{ request.locale.iso_code }}">
   <head>
     {%- render 'stylesheets' -%}
     {{ 'nb-visuals.css' | asset_url | stylesheet_tag }}
@@ -411,48 +407,6 @@ It:
   }
 </style>
 
-<script id="nb-fab-lift-v2">
-(function () {
-  var root = document.documentElement;
-
-  // Look for common Mailchimp bottom-bar wrappers
-  var BAR_SELECTOR = '.mcforms-wrapper, [id^="mcforms-"], [id^="mc-"], [class*="mailchimp"]';
-
-  function num(v){ v = parseFloat(v); return isNaN(v) ? 0 : v; }
-
-  function barHeight(el){
-    if(!el) return 0;
-    var r = el.getBoundingClientRect();
-    var cs = getComputedStyle(el);
-    if (cs.display === 'none' || cs.visibility === 'hidden' || +cs.opacity === 0) return 0;
-    // include external margins to lift cleanly above the pill
-    return Math.round(r.height + num(cs.marginTop) + num(cs.marginBottom));
-  }
-
-  function applyLift(){
-    var bar = document.querySelector(BAR_SELECTOR);
-    var h = barHeight(bar);
-    root.style.setProperty('--nb-fab-lift', (h || 0) + 'px');
-  }
-
-  // Recompute when the bar reflows/animates/opens
-  var mo = new MutationObserver(applyLift);
-
-  function init(){
-    applyLift();
-    var bar = document.querySelector(BAR_SELECTOR);
-    if (bar) mo.observe(bar, { attributes: true, childList: true, subtree: true });
-  }
-
-  if (document.readyState === 'loading'){
-    document.addEventListener('DOMContentLoaded', init);
-  } else {
-    init();
-  }
-
-  window.addEventListener('resize', applyLift, { passive: true });
-})();
-</script>
 <script>
 /* NIBANA — GA4 tracking: global book links (deduped), header CTA, Calendly */
 (function () {
@@ -520,5 +474,6 @@ It:
 {% render 'nb-customer-intake' %}
 <script src="{{ 'nb-lm-widget.js' | asset_url }}" defer></script>
 <script src="{{ 'nb-contact.js' | asset_url }}" defer></script>
+{{ 'nb-fab-lift-v2.js' | asset_url | script_tag }}
   </body>
 </html>


### PR DESCRIPTION
## Summary
- expose the LM provider on the root html tag in a single attribute line and load the reusable FAB lift helper asset once per page
- default the FAB lift CSS custom property and provide a mobile Mailchimp fallback so the FAB clears the widget before JS runs
- add a provider-aware FAB lift enhancer that auto-measures Mailchimp and Shopify UI to keep the button unobstructed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d58d4272e88331865fb23c1bba1260