### PR TITLE
LM landing: switch to Shopify customer form with return_to anchor

### DIFF
--- a/sections/nb-lead-landing.liquid
+++ b/sections/nb-lead-landing.liquid
@@ -80,10 +80,8 @@ Lead Magnet Landing section: hero, bullets, intake form, inline success.
           <div id="nb-lm-views">
             <!-- FORM VIEW -->
             <div id="nb-lm-form-wrap" aria-hidden="false">
-              <form id="nb-lm-form" class="nb-lead-landing__form" method="post" action="{{ routes.root_url }}" novalidate>
-                <input type="hidden" name="form_type" value="customer">
-                <input type="hidden" name="utf8" value="✓">
-                <input type="hidden" name="return_to" value="{{ request.path }}#nb-lm-form">
+              {% form 'customer', id: 'nb-lm-form', class: 'nb-lead-landing__form', novalidate: 'novalidate', return_to: request.path | append: '#nb-lm-form' %}
+                {%- comment -%} Keep tags in a hidden input {%- endcomment -%}
                 <input type="hidden" id="nb-lm-tags" name="contact[tags]" value="{{ base_tag_value }}" data-base="{{ base_tag_value }}" data-nb-lm-tags>
 
                 <div class="nb-lead-landing__fields">
@@ -121,7 +119,7 @@ Lead Magnet Landing section: hero, bullets, intake form, inline success.
                     <p>Please check the highlighted fields and try again.</p>
                   </div>
                 {% endif %}
-              </form>
+              {% endform %}
             </div>
 
             <!-- SUCCESS VIEW -->


### PR DESCRIPTION
## Summary
- replace the manual lead magnet form with Shopify's customer form helper on the landing section
- preserve existing form inputs and behavior while relying on the helper to manage hidden fields and return anchors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b059938c8331aaea109f7721165f