### PR TITLE
CTA: set lead-magnet default to /pages/connection-guide

### DIFF
--- a/snippets/nb-article-ctas.liquid
+++ b/snippets/nb-article-ctas.liquid
@@ -45,7 +45,7 @@
 
   assign url_call_default = '/pages/book-a-call'
   assign url_quiz_default = '/quiz'
-  assign url_leadmagnet_default = ''
+  assign url_leadmagnet_default = '/pages/connection-guide'
 
   assign url_primary = article.metafields.custom.cta_link | default: article.metafields.custom.cta_primary_url | default: ''
   assign url_secondary = article.metafields.custom.cta_secondary_url | default: ''


### PR DESCRIPTION
## Summary
- update the lead magnet CTA default URL in snippets/nb-article-ctas.liquid to /pages/connection-guide
- keep existing fallback logic and CTA selection intact
- spot-check on categories where the lead magnet appears as primary and secondary

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6d9fdeef08331ba1ecaedccd47d9c