### PR TITLE
Quiz result: show counts, single tip for winner, tip card polish

### DIFF
--- a/assets/nb-quiz-surgesignature.css
+++ b/assets/nb-quiz-surgesignature.css
@@ -322,6 +322,10 @@
   font-weight: 600;
   color: var(--nb-text, #203039);
 }
+.nb-quiz__score-count {
+  font-variant-numeric: tabular-nums;
+  color: var(--nb-text-muted, #5e707d);
+}
 .nb-quiz__score-bar {
   grid-column: 1 / -1;
   height: 8px;
@@ -342,6 +346,31 @@
 .nb-quiz__score--accelerator .nb-quiz__score-bar > b { background: #d16c28; }
 .nb-quiz__score--stabiliser  .nb-quiz__score-bar > b { background: #74a29b; }
 .nb-quiz__score--defuser     .nb-quiz__score-bar > b { background: #2f3e48; }
+
+/* Tip card polish */
+.nb-quiz__tip-card {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: 10px;
+  align-items: start;
+  margin-top: 12px;
+  padding: 12px 14px;
+  background: #ffffff;
+  border: 1px solid #E5E7EB;
+  border-left: 4px solid var(--nb-teal, #10636c);
+  border-radius: 12px;
+  box-shadow: 0 6px 18px rgba(0,0,0,.05);
+}
+
+.nb-quiz__tip-icon {
+  line-height: 1;
+  font-size: 18px;
+  margin-top: 2px;
+}
+
+.nb-quiz__tip-text {
+  color: var(--nb-text, #203039);
+}
 
 /* Inputs not overly wide on huge screens */
 @media (min-width: 1200px) {


### PR DESCRIPTION
## Summary
- render quiz score breakdown with x/total counts while keeping animated bars
- add a helper to surface only the winning style quick tip in a highlighted card
- style the score counts and new tip card for better emphasis

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68d6e410e5408331afaac7d5f8f7092c