### PR TITLE
Quiz result: only winner tip, tip card polish, spacing tweak

### DIFF
--- a/assets/nb-quiz-surgesignature.css
+++ b/assets/nb-quiz-surgesignature.css
@@ -180,6 +180,36 @@
   max-width:320px;
 }
 
+/* Tip card polish (single, premium-looking) */
+.nb-quiz__tip-card {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: 10px;
+  align-items: start;
+  padding: 12px 14px;
+  background: #ffffff;
+  border: 1px solid #E5E7EB;
+  border-left: 4px solid var(--nb-teal, #10636c);
+  border-radius: 12px;
+  box-shadow: 0 6px 18px rgba(0,0,0,.05);
+  color: var(--nb-text, #203039);
+}
+
+/* Place the tip a touch LOWER than the scores for visual balance */
+#nb-quiz-tip,
+.nb-quiz__tip,
+.nb-quiz__free-insight {
+  margin-top: clamp(20px, 6vh, 60px);
+}
+
+.nb-quiz__tip-icon {
+  line-height: 1;
+  font-size: 18px;
+  margin-top: 2px;
+}
+
+.nb-quiz__tip-text strong { font-weight: 700; }
+
 /* Result page (page.surge-signature-result) */
 .nb-result .nb-quiz__result-kicker{
   color:color-mix(in srgb, var(--nb-saddle, #7d2921) 90%, #000 10%);

--- a/assets/nb-quiz-surgesignature.js
+++ b/assets/nb-quiz-surgesignature.js
@@ -152,14 +152,28 @@
       }
 
       function renderWinningTip({ quiz, styleKey, tipEl }) {
-        if (!quiz || !styleKey || !tipEl) return;
+        if (!quiz || !styleKey) return;
 
-        var style = quiz.styles && (quiz.styles[styleKey] || (styleKey === 'stabilizer' ? quiz.styles.stabiliser : undefined));
+        // If no #nb-quiz-tip, fall back to any existing "free insight" container
+        tipEl = tipEl || document.getElementById('nb-quiz-tip')
+              || document.querySelector('.nb-quiz__tip, .nb-quiz__free-insight');
+        if (!tipEl) return;
+
+        // Remove / hide any old per-style tip fragments
+        try {
+          document.querySelectorAll('.nb-quiz__tip[data-style], .nb-quiz__free-insight[data-style]')
+            .forEach(function(el){ el.remove(); });
+        } catch (_){ }
+
+        var style = quiz.styles && quiz.styles[styleKey];
         if (!style) return;
 
-        // Prefer a specific tip/practice field; fall back to generic property names
+        // Prefer a specific tip/practice field; fall back gracefully
         var tipText = style.practice || style.tip || style.quick_tip || '';
-        if (!tipText) return;
+        if (!tipText) {
+          tipEl.innerHTML = '';
+          return;
+        }
 
         tipEl.innerHTML = [
           '<div class="nb-quiz__tip-card" role="note">',
@@ -199,8 +213,6 @@
 
         try {
           var scoresEl = document.querySelector('[data-nb-quiz-scores]');
-          var tipEl = document.getElementById('nb-quiz-tip');
-
           var winningKey = style
             || (typeof styleKey !== 'undefined' ? styleKey : null)
             || (state && state.result && state.result.style) || null;
@@ -211,6 +223,9 @@
             container: scoresEl,
             styleKey: winningKey
           });
+
+          var tipEl = document.getElementById('nb-quiz-tip')
+                 || document.querySelector('.nb-quiz__tip, .nb-quiz__free-insight');
 
           renderWinningTip({
             quiz: quiz,

--- a/sections/nb-quiz-surgesignature.liquid
+++ b/sections/nb-quiz-surgesignature.liquid
@@ -27,7 +27,7 @@
           <p class="nb-quiz__summary" data-nb-quiz-summary></p>
           <p class="nb-quiz__trust">We’ll email the full 2-page playbook with tailored practices. GDPR-friendly—no spam.</p>
           <div class="nb-quiz__scores" data-nb-quiz-scores hidden></div>
-          <div class="nb-quiz__free-insight" data-nb-quiz-practice></div>
+          <div id="nb-quiz-tip" class="nb-quiz__tip nb-quiz__free-insight" data-nb-quiz-practice></div>
         </div>
 
         <div id="nb-quiz-gate" class="nb-card nb-quiz__gate">


### PR DESCRIPTION
## Summary
- render a single winning tip card with defensive fallbacks and legacy cleanup
- add spacing and premium card styling for the quiz tip container
- ensure the result template exposes a consistent nb-quiz-tip mount point

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6e8c2c78483319e106c2597ccac85