### PR TITLE
Fix testimonials belt metaobject iteration

### DIFF
--- a/snippets/nb-service-testimonials-belt.liquid
+++ b/snippets/nb-service-testimonials-belt.liquid
@@ -34,8 +34,8 @@ Mode: pass `carousel: true` to enable slider UI.
 
   assign _has_refs = false
   assign _refs     = blank
-  if service and service.testimonials_list
-    assign _refs = service.testimonials_list
+  if service and service.testimonials_list and service.testimonials_list.value != blank
+    assign _refs = service.testimonials_list.value
     if _refs and _refs.size > 0
       assign _has_refs = true
     endif
@@ -52,8 +52,7 @@ Mode: pass `carousel: true` to enable slider UI.
 {%- assign _count = 0 -%}
 {%- capture cards_only -%}
   {%- if _has_refs -%}
-    {%- for ref in _refs -%}
-      {%- assign entry = ref.value -%}
+    {%- for entry in _refs -%}
       {%- if entry -%}
         {%- liquid
           assign include = true


### PR DESCRIPTION
## Summary
- ensure the service testimonials belt iterates over metaobject values rather than refs
- keep tag filtering logic intact while populating testimonial cards directly from entries
- preserve global fallback when a service-specific testimonial list is unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9785516cc833181fb7437e730235d