### PR TITLE
Fix service testimonial belt metaobject handling

### DIFF
--- a/snippets/nb-service-testimonials-belt.liquid
+++ b/snippets/nb-service-testimonials-belt.liquid
@@ -34,8 +34,12 @@ Mode: pass `carousel: true` to enable slider UI.
 
   assign _has_refs = false
   assign _refs     = blank
-  if service and service.testimonials_list and service.testimonials_list.value != blank
-    assign _refs = service.testimonials_list.value
+  if service and service.testimonials_list
+    assign _refs = service.testimonials_list
+    assign _refs_values = _refs | map: 'value'
+    if _refs_values != blank
+      assign _refs = _refs_values
+    endif
     if _refs and _refs.size > 0
       assign _has_refs = true
     endif
@@ -52,7 +56,11 @@ Mode: pass `carousel: true` to enable slider UI.
 {%- assign _count = 0 -%}
 {%- capture cards_only -%}
   {%- if _has_refs -%}
-    {%- for entry in _refs -%}
+    {%- for ref in _refs -%}
+      {%- assign entry = ref -%}
+      {%- if entry == blank and ref.value -%}
+        {%- assign entry = ref.value -%}
+      {%- endif -%}
       {%- if entry -%}
         {%- liquid
           assign include = true


### PR DESCRIPTION
## Summary
- ensure the service testimonials belt treats service-level testimonial lists as present when configured
- normalize testimonial references to actual metaobjects so quote, name, and tag data render correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d97b203dc08331a63d819a8ed1600a