### PR TITLE
Fix service testimonials list dereferencing

### DIFF
--- a/snippets/nb-service-testimonials-belt.liquid
+++ b/snippets/nb-service-testimonials-belt.liquid
@@ -34,11 +34,9 @@ Mode: pass `carousel: true` to enable slider UI.
 
   assign _has_refs = false
   assign _refs     = blank
-  if service and service.testimonials_list
+  if service and service.testimonials_list and service.testimonials_list.size > 0
     assign _refs = service.testimonials_list
-    if _refs and _refs.size > 0
-      assign _has_refs = true
-    endif
+    assign _has_refs = true
   endif
 
   assign _entries = blank
@@ -53,7 +51,7 @@ Mode: pass `carousel: true` to enable slider UI.
 {%- capture cards_only -%}
   {%- if _has_refs -%}
     {%- for ref in _refs -%}
-      {%- assign entry = ref.value -%}
+      {%- assign entry = ref.value | default: ref -%}
       {%- if entry -%}
         {%- liquid
           assign include = true


### PR DESCRIPTION
## Summary
- treat the service testimonials list as metaobject references and flag `_has_refs` when entries exist
- dereference each list item via `ref.value` before rendering testimonial fields so cards populate correctly
- keep existing filtering and fallback paths untouched

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9785516cc833181fb7437e730235d