### PR TITLE
Fix service testimonial belt metaobject usage

### DIFF
--- a/snippets/nb-service-testimonials-belt.liquid
+++ b/snippets/nb-service-testimonials-belt.liquid
@@ -34,9 +34,11 @@ Mode: pass `carousel: true` to enable slider UI.
 
   assign _has_refs = false
   assign _refs     = blank
-  if service and service.testimonials_list and service.testimonials_list.size > 0
-    assign _refs = service.testimonials_list
-    assign _has_refs = true
+  if service and service.testimonials_list
+    assign _refs = service.testimonials_list.value
+    if _refs != blank and _refs.size > 0
+      assign _has_refs = true
+    endif
   endif
 
   assign _entries = blank
@@ -50,8 +52,7 @@ Mode: pass `carousel: true` to enable slider UI.
 {%- assign _count = 0 -%}
 {%- capture cards_only -%}
   {%- if _has_refs -%}
-    {%- for ref in _refs -%}
-      {%- assign entry = ref.value | default: ref -%}
+    {%- for entry in _refs -%}
       {%- if entry -%}
         {%- liquid
           assign include = true


### PR DESCRIPTION
## Summary
- ensure the service testimonial belt resolves curated testimonial metaobject values before rendering
- simplify the testimonial loop to iterate directly over the resolved metaobjects while preserving fallback behavior

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d98036aff883319c28b63787fc2dff