### PR TITLE
Fix testimonials belt to respect service-specific lists

### DIFF
--- a/snippets/nb-service-testimonials-belt.liquid
+++ b/snippets/nb-service-testimonials-belt.liquid
@@ -34,9 +34,9 @@ Mode: pass `carousel: true` to enable slider UI.
 
   assign _has_refs = false
   assign _refs     = blank
-  if service and service.testimonials_list
+  if service and service.testimonials_list and service.testimonials_list.value != blank
     assign _refs = service.testimonials_list.value
-    if _refs != blank and _refs.size > 0
+    if _refs.size > 0
       assign _has_refs = true
     endif
   endif


### PR DESCRIPTION
## Summary
- ensure the service testimonials belt only uses curated references when the metafield contains values
- keep the testimonials loop on curated entries so empty service lists continue to fall back to the global collection

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d981985f448331b4ea8aaf5753c3a2