### PR TITLE
Fix service testimonial belt metaobject handling

### DIFF
--- a/snippets/nb-service-testimonials-belt.liquid
+++ b/snippets/nb-service-testimonials-belt.liquid
@@ -36,8 +36,9 @@ Mode: pass `carousel: true` to enable slider UI.
   assign _refs     = blank
   if service and service.testimonials_list and service.testimonials_list.value != blank
     assign _refs = service.testimonials_list.value
-    if _refs.size > 0
-      assign _has_refs = true
+    if _refs != blank
+      assign _refs = _refs | map: 'value'
+      assign _has_refs = _refs != blank
     endif
   endif
 


### PR DESCRIPTION
## Summary
- ensure the service testimonials list maps metafield entries to metaobjects before rendering
- keep the existing fallback to global testimonials when no curated entries are present

## Testing
- not run (Shopify theme rendering requires storefront access)


------
https://chatgpt.com/codex/tasks/task_e_68d983a658188331976822ce2b124cb4