### PR TITLE
Render hub intro as metafield HTML

### DIFF
--- a/sections/coaching-service.liquid
+++ b/sections/coaching-service.liquid
@@ -67,7 +67,7 @@
 
       {%- if hub_intro != blank -%}
       <div class="nb-tray nb-intro">
-        <div class="rte">{{ hub_intro }}</div>
+        <div class="rte">{{ hub_intro | metafield_tag }}</div>
       </div>
       {%- endif -%}
 


### PR DESCRIPTION
## Summary
- render the hub intro metafield using the metafield_tag filter so formatted content is output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dea1850d008331aff15cc38e810e4b