### PR TITLE
Ensure hub intro retains metafield drop

### DIFF
--- a/sections/coaching-service.liquid
+++ b/sections/coaching-service.liquid
@@ -24,7 +24,7 @@
 {%- if nb_hub -%}
   {%- assign hub_h1      = nb_hub.h1_override | default: page.title -%}
   {%- assign hub_deck    = nb_hub.deck_subheading | default: '' -%}
-  {%- assign hub_intro   = nb_hub.intro_richtext | default: '' -%}
+  {%- assign hub_intro   = nb_hub.intro_richtext -%}
   {%- assign hub_bullets = nb_hub.feature_bullets | default: '' -%}
   {%- assign hub_cta_h   = nb_hub.cta_headline | default: '' -%}
   {%- assign hub_cta_txt = nb_hub.cta_text | default: 'Book a discovery call' -%}
@@ -65,7 +65,7 @@
         {%- if hub_deck != blank -%}<p class="lead rte">{{ hub_deck }}</p>{%- endif -%}
       </div>
 
-      {%- if hub_intro != blank -%}
+      {%- if hub_intro and hub_intro.value != blank -%}
       <div class="nb-tray nb-intro">
         <div class="rte">{{ hub_intro | metafield_tag }}</div>
       </div>


### PR DESCRIPTION
## Summary
- keep the hub intro metafield drop intact by removing the default fallback
- tighten the guard so the intro tray renders only when the metafield is present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dea6efc4d08331949708d11fc6778f