### PR TITLE
SEO Hub fixes: proof from SeoHub, bullets, related by tag, Global FAQ blocks, rich text & styling

### DIFF
--- a/sections/coaching-service.liquid
+++ b/sections/coaching-service.liquid
@@ -22,17 +22,17 @@
   endif
 -%}
 {%- if nb_hub -%}
-  {%- assign hub_h1      = nb_hub.h1_override | default: page.title -%}
+  {%- assign hub_h1      = nb_hub.h1_override.value | default: page.title -%}
   {%- assign hub_deck    = nb_hub.deck_subheading -%}
   {%- assign hub_intro   = nb_hub.intro_richtext -%}
-  {%- assign hub_bullets = nb_hub.feature_bullets | default: '' -%}
-  {%- assign hub_cta_h   = nb_hub.cta_headline | default: '' -%}
-  {%- assign hub_cta_txt = nb_hub.cta_text | default: 'Book a discovery call' -%}
-  {%- assign hub_cta_url = nb_hub.cta_url  | default: '/pages/book-a-call' -%}
-  {%- assign hub_schema  = nb_hub.schema_type | default: 'Service' -%}
-  {%- assign hub_show_faq = nb_hub.show_faq | default: false -%}
-  {%- assign hub_show_trust = nb_hub.show_trustbelt | default: true -%}
-  {%- assign hub_trust_variant = nb_hub.logo_belt_variant | default: 'marquee' -%}
+  {%- assign hub_bullets = nb_hub.feature_bullets.value -%}
+  {%- assign hub_cta_h   = nb_hub.cta_headline.value | default: '' -%}
+  {%- assign hub_cta_txt = nb_hub.cta_text.value    | default: 'Book a discovery call' -%}
+  {%- assign hub_cta_url = nb_hub.cta_url.value     | default: '/pages/book-a-call' -%}
+  {%- assign hub_schema  = nb_hub.schema_type.value | default: 'Service' -%}
+  {%- assign hub_show_faq = nb_hub.show_faq.value | default: false -%}
+  {%- assign hub_show_trust = nb_hub.show_trustbelt.value | default: true -%}
+  {%- assign hub_trust_variant = nb_hub.logo_belt_variant.value | default: 'marquee' -%}
   {%- assign hub_tag = 'hub:' | append: page.handle -%}
 
   {%- if request.design_mode -%}
@@ -58,6 +58,20 @@
     </div>
   {%- endif -%}
 
+  <style>
+    .nb-hub .nb-shell{max-width:var(--narrow-page-width,1120px);margin:0 auto;padding:0 20px}
+    .nb-hub .nb-hero{margin:clamp(16px,3vw,28px) 0}
+    .nb-hub .nb-hero .h1{margin:0 0 6px}
+    .nb-hub .nb-tray{background:var(--nb-mist);border-radius:20px;padding:clamp(18px,2.2vw,26px);box-shadow:0 10px 28px rgba(0,0,0,.06)}
+    .nb-hub .nb-intro{margin:clamp(12px,2vw,18px) 0}
+    .nb-hub .nb-benefits{margin:clamp(12px,2vw,18px) 0}
+    .nb-hub .nb-bottom-cta{margin:clamp(18px,3vw,28px) 0}
+    @media (prefers-reduced-motion:no-preference){
+      .nb-hub a.nb-cta{transition:transform .16s ease, box-shadow .16s ease}
+      .nb-hub a.nb-cta:hover{transform:translateY(-1px)}
+    }
+  </style>
+
   <section id="nb-hub-{{ section.id }}" class="nb-hub">
     <div class="nb-shell">
       <div class="nb-hero nb-hero--hub">
@@ -73,18 +87,30 @@
         </div>
       {%- endif -%}
 
-      {%- if hub_bullets != blank and hub_bullets.size > 0 -%}
+      {%- if hub_bullets and hub_bullets.size > 0 -%}
       <div class="nb-tray nb-benefits">
-        <ul class="nb-list">
-          {%- for b in hub_bullets -%}
-            {%- assign bt = b | strip -%}
-            {%- if bt != '' -%}<li>{{ bt }}</li>{%- endif -%}
-          {%- endfor -%}
-        </ul>
+        <div class="nb-method__body">
+          <ul>
+            {%- for b in hub_bullets -%}
+              {%- assign bt = b | strip -%}
+              {%- if bt != '' -%}<li>{{ bt }}</li>{%- endif -%}
+            {%- endfor -%}
+          </ul>
+        </div>
       </div>
       {%- endif -%}
 
-      {%- if hub_has_service -%}
+      {%- assign hub_proofs = nb_hub.proof_items -%}
+      {%- assign hub_proofs_list = blank -%}
+      {%- if hub_proofs and hub_proofs.value and hub_proofs.value != blank -%}
+        {%- assign hub_proofs_list = hub_proofs.value -%}
+      {%- endif -%}
+
+      {%- if hub_proofs_list and hub_proofs_list.size > 0 -%}
+      <div class="nb-tray nb-proof">
+        {%- render 'nb-service-testimonials-belt', refs: hub_proofs_list, limit: 4, carousel: true -%}
+      </div>
+      {%- elsif hub_has_service -%}
       <div class="nb-tray nb-proof">
         {%- render 'nb-service-testimonials-belt', service: service, limit: 4, carousel: true -%}
       </div>
@@ -92,53 +118,64 @@
 
       {%- if section.settings.hub_blog != blank -%}
         {%- render 'nb-related-posts-hub', hub: nb_hub, blog_handle: section.settings.hub_blog, hub_tag: hub_tag, limit: 6 -%}
-      {%- endif -%}
-
-      {%- if hub_show_faq and hub_has_service -%}
-        {%- liquid
-          assign br_tag = '<br />'
-          assign q_raw = service.faqs_q | append: ''
-          assign a_raw = service.faqs_a | append: ''
-          assign q_html = q_raw | newline_to_br
-          assign q_norm = q_html | replace: '<br/>', br_tag | replace: '<br>', br_tag
-          assign q_pipe = q_norm | replace: br_tag, '|||'
-          assign qs     = q_pipe | split: '|||' 
-          assign a_html = a_raw | newline_to_br
-          assign a_norm = a_html | replace: '<br/>', br_tag | replace: '<br>', br_tag | replace: '&nbsp;', ' '
-          assign a_norm = a_norm | replace: '<br /><br /><br />', '§§' | replace: '<br /><br />', '§§' | replace: '<br />  <br />', '§§' | replace: '<br />   <br />', '§§' | replace: '---','§§'
-          assign as     = a_norm | split: '§§'
-          assign q_count = 0
-          for q in qs
-            assign qq = q | strip_html | strip
-            if qq != ''
-              assign q_count = q_count | plus: 1
-            endif
-          endfor
-        -%}
-        {%- if q_count > 0 -%}
-        <div class="nb-tray nb-faq--wrap">
-          <h2 class="nb-faq__title">Frequently asked questions</h2>
-          <div class="nb-faq__list" id="nb-faq-{{ section.id }}-hub">
-            {%- assign idx = 0 -%}
-            {%- for q in qs -%}
-              {%- assign qq = q | strip_html | strip -%}
-              {%- if qq != '' -%}
-                {%- assign a_block = as[idx] | default: '' -%}
-                {%- assign a_clean = a_block | strip -%}
-                {%- assign head6 = a_clean | slice: 0,6 -%}{% assign head5 = a_clean | slice: 0,5 %}{% assign head4 = a_clean | slice: 0,4 %}
-                {%- if head6 == '<br />' -%}{% assign a_clean = a_clean | replace_first: '<br />','' %}{% endif -%}
-                {%- if head5 == '<br/>'  -%}{% assign a_clean = a_clean | replace_first: '<br/>',''  %}{% endif -%}
-                {%- if head4 == '<br>'   -%}{% assign a_clean = a_clean | replace_first: '<br>',''   %}{% endif -%}
-                <details class="nb-faq__item"{% if forloop.first %} open{% endif %}>
-                  <summary class="nb-faq__q">{{ qq }}</summary>
-                  <div class="nb-faq__a rte">{{ a_clean }}</div>
-                </details>
-                {%- assign idx = idx | plus: 1 -%}
-              {%- endif -%}
-            {%- endfor -%}
+      {%- elsif request.design_mode -%}
+        <div class="nb-shell" style="margin:8px 0 0;">
+          <div class="nb-tray" style="padding:10px 12px; border-radius:12px; background:var(--oc-surface);">
+            <div class="rte"><strong>Hub notice:</strong> set <em>“Hub: blog source (for related posts)”</em> in this section to enable related articles.</div>
           </div>
         </div>
+      {%- endif -%}
+
+      {%- comment -%} Hub FAQ (Global-style): per-page blocks {%- endcomment -%}
+      {%- assign hub_faq_items = section.blocks | where: 'type', 'hub_faq_item' -%}
+      {%- assign hub_faq_count = 0 -%}
+      {%- for b in hub_faq_items -%}
+        {%- assign _q = b.settings.q | strip -%}
+        {%- assign _a = b.settings.a | strip -%}
+        {%- if _q != '' and _a != '' -%}
+          {%- assign hub_faq_count = hub_faq_count | plus: 1 -%}
         {%- endif -%}
+      {%- endfor -%}
+      {%- if hub_show_faq and hub_faq_count > 0 -%}
+      <div class="nb-tray nb-faq--wrap">
+        <h2 class="nb-faq__title">{{ section.settings.hub_faq_title | default: 'Frequently asked questions' }}</h2>
+        <div class="nb-faq__list" id="nb-faq-{{ section.id }}-hub">
+          {%- for b in hub_faq_items -%}
+            {%- assign _q = b.settings.q | strip -%}
+            {%- assign _a = b.settings.a | strip -%}
+            {%- if _q != '' and _a != '' -%}
+              <details class="nb-faq__item"{% if forloop.first %} open{% endif %}>
+                <summary class="nb-faq__q">{{ _q }}</summary>
+                <div class="nb-faq__a rte">{{ _a }}</div>
+              </details>
+            {%- endif -%}
+          {%- endfor -%}
+        </div>
+      </div>
+
+      {%- comment -%} FAQ JSON-LD (from blocks) {%- endcomment -%}
+      <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {%- assign _first = true -%}
+          {%- for b in hub_faq_items -%}
+            {%- assign _q = b.settings.q | strip -%}
+            {%- assign _a = b.settings.a | strip -%}
+            {%- if _q != '' and _a != '' -%}
+              {%- if _first == false -%},{%- endif -%}
+              {
+                "@type": "Question",
+                "name": {{ _q | json }},
+                "acceptedAnswer": { "@type": "Answer", "text": {{ _a | json }} }
+              }
+              {%- assign _first = false -%}
+            {%- endif -%}
+          {%- endfor -%}
+        ]
+      }
+      </script>
       {%- endif -%}
 
       {%- if hub_show_trust and hub_has_service -%}
@@ -1682,9 +1719,24 @@
       "type": "blog",
       "id": "hub_blog",
       "label": "Hub: blog source (for related posts)"
+    },
+    {
+      "type": "text",
+      "id": "hub_faq_title",
+      "label": "Hub FAQ title",
+      "default": "Frequently asked questions"
     }
   ],
-  "blocks": [],
+  "blocks": [
+    {
+      "type": "hub_faq_item",
+      "name": "Hub FAQ item",
+      "settings": [
+        { "type": "text", "id": "q", "label": "Question" },
+        { "type": "richtext", "id": "a", "label": "Answer" }
+      ]
+    }
+  ],
   "presets": [
     {
       "name": "Coaching service"

--- a/snippets/nb-related-posts-hub.liquid
+++ b/snippets/nb-related-posts-hub.liquid
@@ -8,18 +8,23 @@
   assign _shown = 0
   assign _picked = ''
   assign nb_related_post_card_css_state = ''
+  assign _hub_tag = hub_tag | default: ''
+  assign _pins = blank
+  if hub and hub.manual_related_handles and hub.manual_related_handles.value
+    assign _pins = hub.manual_related_handles.value
+  endif
 -%}
 {%- if _blog and _blog.articles_count > 0 -%}
   <section class="nb-related nb-related--lux">
     <h2 class="h2 nb-related__heading">Related posts</h2>
     <div class="nb-related__grid nb-related__grid--lux">
-      {%- comment -%} Pass 1: Pinned handles from SeoHub.manual_related_handles {%- endcomment -%}
-      {%- if hub and hub.manual_related_handles and hub.manual_related_handles.size > 0 -%}
-        {%- for h in hub.manual_related_handles -%}
-          {%- assign handle = h | strip -%}
-          {%- if handle != '' and _shown < _take -%}
+      {%- comment -%} Pass 1: Pinned handles from SeoHub.manual_related_handles (exact order) {%- endcomment -%}
+      {%- if _pins and _pins.size > 0 -%}
+        {%- for handle in _pins -%}
+          {%- assign h = handle | strip -%}
+          {%- if h != '' and _shown < _take -%}
             {%- for a in _blog.articles -%}
-              {%- if a.handle == handle -%}
+              {%- if a.handle == h -%}
                 <div class="nb-related__item nb-related__item--lux">
                   <a href="{{ a.url }}" data-analytics-event="related_blog_click" data-hub-slug="{{ page.handle }}" data-post-slug="{{ a.handle }}">
                     {% render 'blog-post-card', article: a, nb_related_post_card_css: nb_related_post_card_css_state %}
@@ -36,11 +41,11 @@
       {%- endif -%}
 
       {%- comment -%} Pass 2: Tag-based top-up (hub:<page.handle>) {%- endcomment -%}
-      {%- if _shown < _take and hub_tag != blank -%}
+      {%- if _shown < _take and _hub_tag != blank -%}
         {%- for a in _blog.articles -%}
           {%- if _shown < _take -%}
             {%- unless _picked contains a.handle -%}
-              {%- if a.tags contains hub_tag -%}
+              {%- if a.tags contains _hub_tag -%}
                 <div class="nb-related__item nb-related__item--lux">
                   <a href="{{ a.url }}" data-analytics-event="related_blog_click" data-hub-slug="{{ page.handle }}" data-post-slug="{{ a.handle }}">
                     {% render 'blog-post-card', article: a, nb_related_post_card_css: nb_related_post_card_css_state %}
@@ -55,9 +60,9 @@
         {%- endfor -%}
       {%- endif -%}
 
-      {%- comment -%} Pass 3: Category-based top-up (supporting_category_handle) {%- endcomment -%}
-      {%- if _shown < _take and hub and hub.supporting_category_handle != blank -%}
-        {%- assign c_handle = hub.supporting_category_handle -%}
+      {%- comment -%} Pass 3: Category-based top-up (optional) {%- endcomment -%}
+      {%- if _shown < _take and hub and hub.supporting_category_handle and hub.supporting_category_handle.value != blank -%}
+        {%- assign c_handle = hub.supporting_category_handle.value -%}
         {%- for a in _blog.articles -%}
           {%- if _shown < _take -%}
             {%- unless _picked contains a.handle -%}

--- a/snippets/nb-service-testimonials-belt.liquid
+++ b/snippets/nb-service-testimonials-belt.liquid
@@ -41,6 +41,14 @@ Mode: pass `carousel: true` to enable slider UI.
     endif
   endif
 
+  {% comment %} Allow explicit refs param (array of nb_testimonial entries), e.g. from SeoHub {% endcomment %}
+  {% if _has_refs == false and refs and refs != blank %}
+    {% assign _refs = refs %}
+    {% if _refs != blank %}
+      {% assign _has_refs = true %}
+    {% endif %}
+  {% endif %}
+
   assign _entries = blank
   if _has_refs == false
     if shop.metaobjects['nb_testimonial'] and shop.metaobjects['nb_testimonial'].values


### PR DESCRIPTION
## Summary
- allow the service testimonials belt snippet to honor explicit nb_testimonial references passed by hub pages
- rebuild the hub related posts snippet to prioritize manual handles, hub tags, and category top-ups with a required blog source
- update the coaching service hub mode to pull .value fields, render rich text, refresh benefits/proof/FAQ blocks, add styling, and surface an editor warning when the related blog is missing

## Testing
- not run (liquid changes only)


------
https://chatgpt.com/codex/tasks/task_e_68debddd779c8331b9fcf416c8228737