### PR TITLE
Normalize inline Liquid syntax in testimonials belt

### DIFF
--- a/snippets/nb-service-testimonials-belt.liquid
+++ b/snippets/nb-service-testimonials-belt.liquid
@@ -41,13 +41,13 @@ Mode: pass `carousel: true` to enable slider UI.
     endif
   endif
 
-  {% comment %} Allow explicit refs param (array of nb_testimonial entries), e.g. from SeoHub {% endcomment %}
-  {% if _has_refs == false and refs and refs != blank %}
-    {% assign _refs = refs %}
-    {% if _refs != blank %}
-      {% assign _has_refs = true %}
-    {% endif %}
-  {% endif %}
+  # Allow explicit refs param (array of nb_testimonial entries), e.g. from SeoHub
+  if _has_refs == false and refs and refs != blank
+    assign _refs = refs
+    if _refs != blank
+      assign _has_refs = true
+    endif
+  endif
 
   assign _entries = blank
   if _has_refs == false


### PR DESCRIPTION
## Summary
- remove Liquid comment block in the service testimonials snippet
- switch the fallback refs logic to brace-free inline Liquid syntax for consistency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dec9b2685083319251f2c1dbd13c00