### PR TITLE
Hub: related-posts handleize + count coercion; NB-FAQ Global styling from SeoHub

### DIFF
--- a/sections/coaching-service.liquid
+++ b/sections/coaching-service.liquid
@@ -22,22 +22,21 @@
   endif
 -%}
 {%- if nb_hub -%}
-  {%- assign hub_h1      = nb_hub.h1_override.value | default: page.title -%}
-  {%- assign hub_deck    = nb_hub.deck_subheading -%}
-  {%- assign hub_intro   = nb_hub.intro_richtext -%}
-  {%- assign hub_bullets = nb_hub.feature_bullets.value -%}
-  {%- assign hub_cta_h   = nb_hub.cta_headline.value | default: '' -%}
-  {%- assign hub_cta_txt = nb_hub.cta_text.value    | default: 'Book a discovery call' -%}
-  {%- assign hub_cta_url = nb_hub.cta_url.value     | default: '/pages/book-a-call' -%}
-  {%- assign hub_schema  = nb_hub.schema_type.value | default: 'Service' -%}
-  {%- assign hub_show_faq = nb_hub.show_faq.value | default: false -%}
-  {%- assign hub_show_trust = nb_hub.show_trustbelt.value | default: true -%}
-  {%- assign hub_trust_variant = nb_hub.logo_belt_variant.value | default: 'marquee' -%}
-  {%- assign hub_tag = 'hub:' | append: page.handle -%}
-
-  {%- assign hub_blog_handle = nb_hub.blog_handle.value | default: '' -%}
-  {%- assign hub_faq_q = nb_hub.faq_q.value | default: '' -%}
-  {%- assign hub_faq_a = nb_hub.faq_a.value | default: '' -%}
+{%- assign hub_h1      = nb_hub.h1_override.value | default: page.title -%}
+{%- assign hub_deck    = nb_hub.deck_subheading -%}
+{%- assign hub_intro   = nb_hub.intro_richtext -%}
+{%- assign hub_bullets = nb_hub.feature_bullets.value -%}
+{%- assign hub_cta_h   = nb_hub.cta_headline.value | default: '' -%}
+{%- assign hub_cta_txt = nb_hub.cta_text.value    | default: 'Book a discovery call' -%}
+{%- assign hub_cta_url = nb_hub.cta_url.value     | default: '/pages/book-a-call' -%}
+{%- assign hub_schema  = nb_hub.schema_type.value | default: 'Service' -%}
+{%- assign hub_show_faq = nb_hub.show_faq.value | default: false -%}
+{%- assign hub_show_trust = nb_hub.show_trustbelt.value | default: true -%}
+{%- assign hub_trust_variant = nb_hub.logo_belt_variant.value | default: 'marquee' -%}
+{%- assign hub_tag = 'hub:' | append: page.handle -%}
+{%- assign hub_blog_handle = nb_hub.blog_handle.value | default: '' -%}
+{%- assign hub_faq_q = nb_hub.faq_q.value | default: '' -%}
+{%- assign hub_faq_a = nb_hub.faq_a.value | default: '' -%}
 
   {%- if request.design_mode -%}
     <div class="nb-shell" style="margin:8px 0 0;">
@@ -125,12 +124,12 @@
       {%- elsif request.design_mode -%}
         <div class="nb-shell" style="margin:8px 0 0;">
           <div class="nb-tray" style="padding:10px 12px; border-radius:12px; background:var(--oc-surface);">
-            <div class="rte"><strong>Hub notice:</strong> set <em>SeoHub → blog_handle</em> (e.g., <code>blog</code>) to enable related articles.</div>
+            <div class="rte"><strong>Hub notice:</strong> set <em>SeoHub → blog_handle</em> to the blog handle (e.g., <code>nibana-journal</code>).</div>
           </div>
         </div>
       {%- endif -%}
 
-      {%- comment -%} Hub FAQ (Global-style) from SeoHub faq_q / faq_a {%- endcomment -%}
+      {%- comment -%} NB-FAQ Global styling — content from SeoHub (faq_q / faq_a) {%- endcomment -%}
       {%- if hub_show_faq -%}
         {%- liquid
           assign br_tag = '<br />'
@@ -156,7 +155,7 @@
           endfor
         -%}
         {%- if q_count > 0 -%}
-          <div class="nb-tray nb-faq--wrap">
+          <section class="nb-faq nb-tray">
             <h2 class="nb-faq__title">Frequently asked questions</h2>
             <div class="nb-faq__list" id="nb-faq-{{ section.id }}-hub">
               {%- assign idx = 0 -%}
@@ -177,9 +176,9 @@
                 {%- endif -%}
               {%- endfor -%}
             </div>
-          </div>
+          </section>
 
-          {%- comment -%} FAQ JSON-LD {%- endcomment -%}
+          {%- comment -%} FAQ JSON-LD (NB-FAQ Global content) {%- endcomment -%}
           <script type="application/ld+json">
           {
             "@context": "https://schema.org",

--- a/snippets/nb-related-posts-hub.liquid
+++ b/snippets/nb-related-posts-hub.liquid
@@ -1,24 +1,33 @@
 {%- liquid
-  assign _blog_handle = blog_handle | default: '' 
+  assign _raw_handle = blog_handle | default: '' | strip
   assign _blog = nil
-  if _blog_handle != '' 
-    assign _blog = blogs[_blog_handle]
+  if _raw_handle != ''
+    assign _blog = blogs[_raw_handle]
+    if _blog == nil
+      assign _handleized = _raw_handle | handleize
+      assign _blog = blogs[_handleized]
+    endif
   endif
+
   assign _take = limit | default: 6
   assign _shown = 0
   assign _picked = ''
   assign nb_related_post_card_css_state = ''
   assign _hub_tag = hub_tag | default: ''
+
   assign _pins = blank
   if hub and hub.manual_related_handles and hub.manual_related_handles.value
     assign _pins = hub.manual_related_handles.value
   endif
 -%}
-{%- if _blog and _blog.articles_count > 0 -%}
+{%- if _blog -%}
+  {%- assign _articles_count = _blog.articles_count | plus: 0 -%}
+{%- endif -%}
+{%- if _blog and _articles_count > 0 -%}
   <section class="nb-related nb-related--lux">
     <h2 class="h2 nb-related__heading">Related posts</h2>
     <div class="nb-related__grid nb-related__grid--lux">
-      {%- comment -%} Pass 1: Pinned handles from SeoHub.manual_related_handles (exact order) {%- endcomment -%}
+      {%- comment -%} Pass 1: Pinned handles (exact order) {%- endcomment -%}
       {%- if _pins and _pins.size > 0 -%}
         {%- for handle in _pins -%}
           {%- assign h = handle | strip -%}
@@ -83,4 +92,10 @@
       {%- endif -%}
     </div>
   </section>
+{%- elsif request.design_mode -%}
+  <div class="nb-shell" style="margin:8px 0 0;">
+    <div class="nb-tray" style="padding:10px 12px; border-radius:12px; background:var(--oc-surface);">
+      <div class="rte"><strong>Hub notice:</strong> <code>seo_hub.blog_handle</code> should be the blog <em>handle</em> (e.g., <code>nibana-journal</code>), not the title “Nibana Journal”.</div>
+    </div>
+  </div>
 {%- endif -%}


### PR DESCRIPTION
## Summary
- handleize the SeoHub blog handle in the related posts snippet and coerce the article count before rendering
- update the SeoHub FAQ markup to use the NB-FAQ global styling and emit structured data
- adjust the design mode notice to clarify the expected blog handle when related posts are unavailable

## Testing
- not run (liquid-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68decc4e5b8c83318de219ed21e19a9b