### PR TITLE
Fix FAQ JSON-LD comma handling in coaching service section

### DIFF
--- a/sections/coaching-service.liquid
+++ b/sections/coaching-service.liquid
@@ -1408,7 +1408,8 @@
         {%- assign q = qs[i] | strip_html | strip -%}
         {%- assign a_html = as[i] | strip -%}
         {%- if q != '' and a_html != '' -%}
-          {%- unless first -%},          {
+          {%- unless first -%},{%- endunless -%}
+          {
             "@type": "Question",
             "name": {{ q | json }},
             "acceptedAnswer": {


### PR DESCRIPTION
## Summary
- correct the FAQ JSON-LD loop so commas are emitted without invalid Liquid syntax

## Testing
- not run (theme CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68deda78f4e48331856f7f485598e436