### PR TITLE
Testimonials belt: support explicit refs (SeoHub) with service fallback

### DIFF
--- a/snippets/nb-service-testimonials-belt.liquid
+++ b/snippets/nb-service-testimonials-belt.liquid
@@ -1,3 +1,10 @@
+{%- liquid
+  assign __nb_refs_from_param = false
+  if refs and refs != blank
+    assign __nb_refs_from_param = true
+  endif
+-%}
+
 {%- comment -%}
 Service-page testimonials belt — grid/slider using the same classes as Testimonials.
 
@@ -40,6 +47,11 @@ Mode: pass `carousel: true` to enable slider UI.
       assign _has_refs = true
     endif
   endif
+
+  {%- if __nb_refs_from_param and refs != blank -%}
+    {%- assign _refs = refs -%}
+    {%- assign _has_refs = true -%}
+  {%- endif -%}
 
   # Allow explicit refs param (array of nb_testimonial entries), e.g. from SeoHub
   if _has_refs == false and refs and refs != blank


### PR DESCRIPTION
## Summary
- allow testimonials belt to detect when refs are provided explicitly
- ensure the service testimonial list is overridden when explicit refs are passed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dede3149788331bdb3f69933468498