### PR TITLE
Fix Liquid syntax for refs override

### DIFF
--- a/snippets/nb-service-testimonials-belt.liquid
+++ b/snippets/nb-service-testimonials-belt.liquid
@@ -1,3 +1,10 @@
+{%- liquid
+  assign __nb_refs_from_param = false
+  if refs and refs != blank
+    assign __nb_refs_from_param = true
+  endif
+-%}
+
 {%- comment -%}
 Service-page testimonials belt — grid/slider using the same classes as Testimonials.
 
@@ -39,6 +46,11 @@ Mode: pass `carousel: true` to enable slider UI.
     if _refs != blank
       assign _has_refs = true
     endif
+  endif
+
+  if __nb_refs_from_param and refs != blank
+    assign _refs = refs
+    assign _has_refs = true
   endif
 
   # Allow explicit refs param (array of nb_testimonial entries), e.g. from SeoHub


### PR DESCRIPTION
## Summary
- ensure the explicit refs override runs inside the liquid tag without template syntax

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dede3149788331bdb3f69933468498