### PR TITLE
Hub: make testimonials render from SeoHub (refs) with service fallback; add editor debug

### DIFF
--- a/sections/seo-hub.liquid
+++ b/sections/seo-hub.liquid
@@ -129,9 +129,21 @@
       {%- if hub.proof_items and hub.proof_items.value and hub.proof_items.value != blank -%}
         {%- assign hub_proofs_list = hub.proof_items.value -%}
       {%- endif -%}
-      {%- if hub_proofs_list and hub_proofs_list.size > 0 -%}
+      {%- assign __hub_proofs_count = 0 -%}
+      {%- if hub_proofs_list != blank -%}
+        {%- for _t in hub_proofs_list -%}{%- assign __hub_proofs_count = __hub_proofs_count | plus: 1 -%}{%- endfor -%}
+      {%- endif -%}
+
+      {%- if __hub_proofs_count > 0 -%}
         <div class="nb-tray nb-proof">
-          {%- render 'nb-service-testimonials-belt', refs: hub_proofs_list, limit: 4, carousel: true -%}
+          {%- comment -%} pass service too (some belts expect it) {%- endcomment -%}
+          {%- render 'nb-service-testimonials-belt', refs: hub_proofs_list, service: service, limit: 4, carousel: true -%}
+        </div>
+      {%- elsif request.design_mode -%}
+        <div class="nb-shell" style="margin:8px 0 0;">
+          <div class="nb-tray" style="padding:10px 12px; border-radius:12px; background:var(--oc-surface);">
+            <div class="rte"><strong>Hub debug:</strong> SeoHub has <code>{{ __hub_proofs_count }}</code> testimonial picks. Check SeoHub → proof_items.</div>
+          </div>
         </div>
       {%- endif -%}
 

--- a/snippets/nb-service-testimonials-belt.liquid
+++ b/snippets/nb-service-testimonials-belt.liquid
@@ -18,6 +18,11 @@ Mode: pass `carousel: true` to enable slider UI.
 {%- endcomment -%}
 
 {%- liquid
+  assign _refs = blank
+  assign _has_refs = false
+-%}
+
+{%- liquid
   assign _heading  = heading  | default: 'What our clients say'
   assign _limit    = limit    | default: 4
   assign _carousel = carousel | default: false
@@ -47,7 +52,14 @@ Mode: pass `carousel: true` to enable slider UI.
       assign _has_refs = true
     endif
   endif
+-%}
 
+{%- if refs and refs != blank -%}
+  {%- assign _refs = refs -%}
+  {%- assign _has_refs = true -%}
+{%- endif -%}
+
+{%- liquid
   if __nb_refs_from_param and refs != blank
     assign _refs = refs
     assign _has_refs = true
@@ -69,6 +81,16 @@ Mode: pass `carousel: true` to enable slider UI.
     endif
   endif
 -%}
+
+{%- if request.design_mode -%}
+  <div class="nb-shell" style="margin:8px 0;">
+    <div class="nb-tray" style="padding:8px 10px; border-radius:12px; background:var(--oc-surface);">
+      <div class="rte">Testimonials belt source:
+        {%- if refs and refs != blank -%}<strong>SeoHub refs</strong>{%- elsif service -%}<strong>Service list</strong>{%- else -%}<strong>none</strong>{%- endif -%}
+      </div>
+    </div>
+  </div>
+{%- endif -%}
 
 {%- assign _count = 0 -%}
 {%- capture cards_only -%}


### PR DESCRIPTION
## Summary
- ensure the SeoHub testimonials block counts selected refs, passes the service to the belt, and shows an editor notice when no picks are configured
- initialize testimonial refs in the belt snippet, honor explicit refs even when a service is present, and surface a design-mode source indicator

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68dee2ebdf0c83319c5fa0b59bd23e22