### PR TITLE
SEO Hub luxury styling: hero eyebrow, refined spacing, intro measure, benefits grid, related cards polish, trustbelt eyebrow, CTA callout

### DIFF
--- a/sections/seo-hub.liquid
+++ b/sections/seo-hub.liquid
@@ -85,21 +85,60 @@
 
   <section id="nb-hub-{{ section.id }}" class="nb-hub">
     <style>
+      /* Shell & rhythm */
       .nb-hub .nb-shell{max-width:var(--narrow-page-width,1120px);margin:0 auto;padding:0 20px}
-      .nb-hub .nb-hero{margin:clamp(16px,3vw,28px) 0}
-      .nb-hub .nb-hero .h1{margin:0 0 6px}
-      .nb-hub .nb-tray{background:var(--nb-mist);border-radius:20px;padding:clamp(18px,2.2vw,26px);box-shadow:0 10px 28px rgba(0,0,0,.06)}
-      .nb-hub .nb-intro{margin:clamp(12px,2vw,18px) 0}
-      .nb-hub .nb-benefits{margin:clamp(12px,2vw,18px) 0}
-      .nb-hub .nb-bottom-cta{margin:clamp(18px,3vw,28px) 0}
+      .nb-hub .nb-hero{margin:clamp(28px,6vw,72px) 0}
+      .nb-hub .nb-tray{background:var(--nb-mist);border-radius:20px;padding:clamp(22px,3vw,34px);box-shadow:0 10px 28px rgba(0,0,0,.06)}
+      .nb-hub .nb-intro{margin:clamp(18px,3vw,32px) 0}
+      .nb-hub .nb-benefits{margin:clamp(18px,3vw,32px) 0}
+      .nb-hub .nb-bottom-cta{margin:clamp(28px,6vw,64px) 0;text-align:center}
+
+      /* Hero */
+      .nb-hub .nb-eyebrow{display:inline-block;margin:0 0 8px;letter-spacing:.08em;text-transform:uppercase;font-size:.78rem;font-weight:700;color:color-mix(in oklab, var(--color-foreground, #111), #000 20%);opacity:.7}
+      .nb-hub .nb-hero .h1{margin:0 0 8px}
+      .nb-hub .lead{font-weight:500;line-height:1.6}
+
+      /* Intro measure (editorial) */
+      .nb-hub .nb-intro .rte{max-width:68ch;margin:0 auto}
+      .nb-hub .nb-intro .rte p:first-child{font-weight:600}
+
+      /* Benefits grid (chips) */
+      .nb-hub .nb-benefits .nb-method__body ul{display:grid;gap:12px;grid-template-columns:1fr}
+      @media (min-width:700px){.nb-hub .nb-benefits .nb-method__body ul{grid-template-columns:1fr 1fr}}
+      @media (min-width:1024px){.nb-hub .nb-benefits .nb-method__body ul{grid-template-columns:1fr 1fr 1fr}}
+      .nb-hub .nb-benefits .nb-method__body ul li{padding:12px 14px;border-radius:9999px;background:rgba(255,255,255,.6);box-shadow:0 1px 8px rgba(0,0,0,.04)}
+
+      /* Related posts polish */
+      .nb-hub .nb-related__grid{gap:clamp(12px,2vw,18px)}
+      .nb-hub .nb-related__item a{display:block;border-radius:16px;overflow:hidden;box-shadow:0 6px 18px rgba(0,0,0,.06);transition:transform .18s ease, box-shadow .18s ease}
+      .nb-hub .nb-related__item a:hover{transform:translateY(-1px);box-shadow:0 12px 26px rgba(0,0,0,.08)}
+      .nb-hub .nb-related__item img{width:100%;height:auto;object-fit:cover}
+      .nb-hub .nb-related__heading{margin:0 0 8px;text-align:center}
+
+      /* Trust belt label */
+      .nb-hub .nb-trust-eyebrow{margin:18px 0 10px;text-align:center;letter-spacing:.08em;text-transform:uppercase;font-size:.8rem;font-weight:700;opacity:.7}
+
+      /* CTA callout */
+      .nb-hub .nb-cta{display:inline-block;border-radius:9999px;padding:14px 22px;box-shadow:0 8px 22px rgba(0,0,0,.08);transition:transform .18s ease, box-shadow .18s ease}
+      .nb-hub .nb-cta:hover{transform:translateY(-1px);box-shadow:0 12px 28px rgba(0,0,0,.12)}
+      .nb-hub .nb-cta-note{margin:10px 0 0;opacity:.8}
+      .nb-hub .nb-cta-secondary{margin-top:8px;display:block;font-size:.92rem;text-decoration:underline;opacity:.8}
       @media (prefers-reduced-motion:no-preference){
-        .nb-hub a.nb-cta{transition:transform .16s ease, box-shadow .16s ease}
-        .nb-hub a.nb-cta:hover{transform:translateY(-1px)}
+        .nb-hub a{transition:transform .18s ease, box-shadow .18s ease}
       }
     </style>
 
     <div class="nb-shell">
       <div class="nb-hero nb-hero--hub">
+        {%- liquid
+          assign hub_eyebrow = ''
+          if hub.eyebrow_label and hub.eyebrow_label.value != blank
+            assign hub_eyebrow = hub.eyebrow_label.value
+          elsif service and service.title != blank
+            assign hub_eyebrow = service.title
+          endif
+        -%}
+        {%- if hub_eyebrow != '' -%}<p class="nb-eyebrow">{{ hub_eyebrow }}</p>{%- endif -%}
         <h1 class="h1">{{ hub_h1 }}</h1>
         {%- if hub_deck != blank -%}
           <div class="lead rte">{{ hub_deck | metafield_tag }}</div>
@@ -232,19 +271,20 @@
       {%- endif -%}
 
       {%- if hub_show_trust and service -%}
+        <div class="nb-trust-eyebrow">Trusted by</div>
         {%- liquid
           assign sp_raw  = service.social_proof | append: ''
           assign sp_html = sp_raw | newline_to_br
           assign br_tag  = '<br />'
           assign sp_norm = sp_html | replace: '<br/>', br_tag | replace: '<br>', br_tag
-          assign sp_pipe = sp_norm | replace: br_tag, '|||' 
-          assign sp      = sp_pipe | split: '|||' 
+          assign sp_pipe = sp_norm | replace: br_tag, '|||'
+          assign sp      = sp_pipe | split: '|||'
           assign _layout = hub_trust_variant | default: 'marquee'
         -%}
-        {%- render 'nb-trustbelt-core', items: sp, layout: _layout, speed: 22 -%}
+        {%- render 'nb-trustbelt-core', items: sp, layout: _layout, speed: 16 -%}
       {%- endif -%}
 
-      <div class="nb-tray nb-bottom-cta" style="text-align:center;">
+      <div class="nb-tray nb-bottom-cta">
         {%- if hub_cta_h != blank -%}<h2 class="h3" style="margin:0 0 8px;">{{ hub_cta_h }}</h2>{%- endif -%}
         <a class="nb-cta nb-cta--xl" href="{{ hub_cta_url }}"
           data-analytics-event="hub_cta_click"
@@ -253,6 +293,12 @@
           data-cta-location="bottom">
           {{ hub_cta_txt }}
         </a>
+        {%- if hub.cta_note and hub.cta_note.value != blank -%}
+          <p class="nb-cta-note">{{ hub.cta_note.value }}</p>
+        {%- endif -%}
+        {%- if hub.cta_secondary_text and hub.cta_secondary_text.value != blank and hub.cta_secondary_url and hub.cta_secondary_url.value != blank -%}
+          <a class="nb-cta-secondary" href="{{ hub.cta_secondary_url.value }}">{{ hub.cta_secondary_text.value }}</a>
+        {%- endif -%}
       </div>
     </div>
   </section>

--- a/snippets/nb-related-posts-hub.liquid
+++ b/snippets/nb-related-posts-hub.liquid
@@ -32,7 +32,7 @@
             {%- for a in _blog.articles -%}
               {%- if a.handle == h -%}
                 <div class="nb-related__item nb-related__item--lux">
-                  <a href="{{ a.url }}" data-analytics-event="related_blog_click" data-hub-slug="{{ page.handle }}" data-post-slug="{{ a.handle }}">
+                  <a class="nb-related__link" href="{{ a.url }}" data-analytics-event="related_blog_click" data-hub-slug="{{ page.handle }}" data-post-slug="{{ a.handle }}">
                     {% render 'blog-post-card', article: a, nb_related_post_card_css: nb_related_post_card_css_state %}
                   </a>
                 </div>
@@ -52,7 +52,7 @@
             {%- unless _picked contains a.handle -%}
               {%- if a.tags contains _hub_tag -%}
                 <div class="nb-related__item nb-related__item--lux">
-                  <a href="{{ a.url }}" data-analytics-event="related_blog_click" data-hub-slug="{{ page.handle }}" data-post-slug="{{ a.handle }}">
+                  <a class="nb-related__link" href="{{ a.url }}" data-analytics-event="related_blog_click" data-hub-slug="{{ page.handle }}" data-post-slug="{{ a.handle }}">
                     {% render 'blog-post-card', article: a, nb_related_post_card_css: nb_related_post_card_css_state %}
                   </a>
                 </div>
@@ -73,7 +73,7 @@
               {%- assign a_cat = a.metafields.custom.primary_category | default: '' -%}
               {%- if a_cat == c_handle -%}
                 <div class="nb-related__item nb-related__item--lux">
-                  <a href="{{ a.url }}" data-analytics-event="related_blog_click" data-hub-slug="{{ page.handle }}" data-post-slug="{{ a.handle }}">
+                  <a class="nb-related__link" href="{{ a.url }}" data-analytics-event="related_blog_click" data-hub-slug="{{ page.handle }}" data-post-slug="{{ a.handle }}">
                     {% render 'blog-post-card', article: a, nb_related_post_card_css: nb_related_post_card_css_state %}
                   </a>
                 </div>


### PR DESCRIPTION
## Summary
- refresh the SEO hub inline styles for expanded spacing, hero eyebrow, editorial intro measure, pill benefits, related card hover, trust label, and CTA callout
- inject a dynamic hero eyebrow that favors the hub eyebrow metafield, falling back to the bound service title
- add the "Trusted by" label with calmer marquee speed and support optional CTA note/secondary link while tagging related post links for hover polish

## Testing
- Not run (Liquid changes only)


------
https://chatgpt.com/codex/tasks/task_e_68dee9e919dc8331aced94cd74452ab6