### PR TITLE
Hub: make “From the Nibana Journal” match blog cards + responsive fixes

### DIFF
--- a/assets/nb-article-card.css
+++ b/assets/nb-article-card.css
@@ -1,0 +1,81 @@
+.nb-article-card {
+  height: 100%;
+}
+
+.nb-article-card__link {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(12px, 2.2vw, 20px);
+  height: 100%;
+  text-decoration: none;
+  color: inherit;
+}
+
+.nb-article-card__image {
+  border-radius: var(--radius-2xl, 16px);
+  overflow: hidden;
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.08);
+}
+
+.nb-article-card__image img {
+  display: block;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  border-radius: var(--radius-2xl, 16px);
+}
+
+.nb-article-card__content {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(8px, 1.4vw, 16px);
+}
+
+.nb-article-card__title {
+  margin: 0;
+  font-size: clamp(1.25rem, 2.2vw, 1.65rem);
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  word-break: normal;
+  overflow-wrap: anywhere;
+  hyphens: auto;
+  line-height: 1.2;
+}
+
+.nb-article-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  color: rgb(var(--color-foreground-rgb, 17 17 17) / var(--opacity-subdued-text, 0.7));
+  font-size: var(--font-size--body-sm, 0.95rem);
+}
+
+.nb-article-card__meta > * {
+  margin: 0;
+}
+
+.nb-article-card__date time {
+  font: inherit;
+}
+
+.nb-article-card__sep {
+  margin-inline: 0.25rem;
+}
+
+.nb-article-card__excerpt {
+  margin: 0;
+  color: rgb(var(--color-foreground-rgb, 17 17 17) / var(--opacity-subdued-text, 0.7));
+  line-height: 1.5;
+}
+
+.nb-article-card__link:hover .nb-article-card__title,
+.nb-article-card__link:focus-visible .nb-article-card__title {
+  text-decoration: underline;
+}
+
+.nb-article-card__link:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 4px;
+}

--- a/sections/seo-hub.liquid
+++ b/sections/seo-hub.liquid
@@ -108,9 +108,15 @@
       @media (min-width:1024px){.nb-hub .nb-benefits .nb-method__body ul{grid-template-columns:1fr 1fr 1fr}}
       .nb-hub .nb-benefits .nb-method__body ul li{padding:12px 14px;border-radius:9999px;background:rgba(255,255,255,.6);box-shadow:0 1px 8px rgba(0,0,0,.04)}
 
-      /* Hub: map blog posts grid */
-      .nb-hub .blog-posts-container--hub{display:grid;gap:clamp(18px,2.4vw,28px);grid-template-columns:1fr}
-      @media (min-width:900px){.nb-hub .blog-posts-container--hub{grid-template-columns:1fr 1fr}}
+      /* Hub: related posts */
+      .nb-hub .nb-related-posts{margin-top:clamp(24px,4vw,48px)}
+      .nb-hub .nb-related-posts .nb-shell{max-width:1200px;margin-inline:auto;padding-inline:16px}
+      .nb-hub .nb-related-posts__header{margin-bottom:clamp(12px,2.5vw,24px)}
+      .nb-hub .nb-related-posts__title{margin:0;font-size:clamp(22px,2.2vw,36px);font-weight:700;letter-spacing:-.02em}
+      .nb-hub .nb-posts-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-6,24px);align-items:start}
+      .nb-hub .nb-related-posts .panel,
+      .nb-hub .nb-related-posts .nb-card,
+      .nb-hub .nb-related-posts .nb-bubble{background:transparent !important;box-shadow:none !important;padding:0 !important;border-radius:0 !important}
 
       /* Trust belt label */
       .nb-hub .nb-trust-eyebrow{margin:18px 0 10px;text-align:center;letter-spacing:.08em;text-transform:uppercase;font-size:.8rem;font-weight:700;opacity:.7}

--- a/snippets/nb-article-card.liquid
+++ b/snippets/nb-article-card.liquid
@@ -1,0 +1,46 @@
+{%- liquid
+  assign card_article = article
+  assign card_body = body
+-%}
+{%- if card_article == blank -%}
+  {%- comment -%}No article to render{%- endcomment -%}
+{%- else -%}
+  {%- liquid
+    assign image_alt = ''
+    if card_article.image
+      assign image_alt = card_article.image.alt | default: card_article.title
+      assign image_alt = image_alt | strip | escape
+    endif
+
+    assign excerpt_text = card_body | default: card_article.excerpt_or_content | strip_html | truncate: 140
+    assign excerpt_text = excerpt_text | strip
+  -%}
+  {%- unless nb_article_card_css -%}
+    {% assign nb_article_card_css = true %}
+    {{ 'nb-article-card.css' | asset_url | stylesheet_tag }}
+  {%- endunless -%}
+  <article class="nb-article-card">
+    <a class="nb-article-card__link" href="{{ card_article.url }}">
+      {%- if card_article.image -%}
+        <div class="nb-article-card__image">
+          {{ card_article.image
+            | image_url: width: 960
+            | image_tag: loading: 'lazy', sizes: '(min-width: 1024px) 33vw, 90vw', widths: '480,720,960', alt: image_alt }}
+        </div>
+      {%- endif -%}
+      <div class="nb-article-card__content">
+        <h3 class="nb-article-card__title">{{ card_article.title | escape }}</h3>
+        <div class="nb-article-card__meta">
+          {%- if card_article.published_at -%}
+            <span class="nb-article-card__date">{{ card_article.published_at | time_tag: format: 'date' }}</span>
+            <span class="nb-article-card__sep" aria-hidden="true">·</span>
+          {%- endif -%}
+          <span class="nb-article-card__read">{% render 'reading-time', article: card_article %}</span>
+        </div>
+        {%- if excerpt_text != '' -%}
+          <p class="nb-article-card__excerpt">{{ excerpt_text }}</p>
+        {%- endif -%}
+      </div>
+    </a>
+  </article>
+{%- endif -%}

--- a/snippets/nb-related-posts-hub.liquid
+++ b/snippets/nb-related-posts-hub.liquid
@@ -13,7 +13,6 @@
   assign _shown = 0
   assign _picked = ''
   assign _hub_tag = hub_tag | default: ''
-
   assign _pins = blank
   if hub and hub.manual_related_handles and hub.manual_related_handles.value
     assign _pins = hub.manual_related_handles.value
@@ -26,61 +25,59 @@
   if _heading == ''
     assign _heading = 'From the Nibana Journal'
   endif
+
+  assign articles = array
+  assign _articles_count = 0
+  if _blog
+    assign _articles_count = _blog.articles_count | plus: 0
+  endif
+
+  if _blog and _articles_count > 0
+    if _pins and _pins.size > 0
+      for handle in _pins
+        assign h = handle | strip
+        if h != '' and _shown < _take
+          for a in _blog.articles
+            if a.handle == h
+              assign articles = articles | push: a
+              assign _picked = _picked | append: a.handle | append: ','
+              assign _shown = _shown | plus: 1
+              break
+            endif
+          endfor
+        endif
+      endfor
+    endif
+
+    if _shown < _take and _hub_tag != blank
+      for a in _blog.articles
+        if _shown < _take
+          unless _picked contains a.handle
+            if a.tags contains _hub_tag
+              assign articles = articles | push: a
+              assign _picked = _picked | append: a.handle | append: ','
+              assign _shown = _shown | plus: 1
+            endif
+          endunless
+        endif
+      endfor
+    endif
+  endif
+
+  assign _selected_count = articles | size
 -%}
-{%- if _blog -%}{%- assign _articles_count = _blog.articles_count | plus: 0 -%}{%- endif -%}
-{%- if _blog and _articles_count > 0 -%}
-  <section class="nb-related nb-related--xl">
-    <h2 class="h2 nb-related__heading">{{ _heading }}</h2>
+{%- if _selected_count > 0 -%}
+  <section class="nb-related-posts">
+    <div class="nb-shell">
+      <header class="nb-related-posts__header">
+        <h2 class="nb-related-posts__title">{{ _heading }}</h2>
+      </header>
 
-    <!-- Match blog page container + item classes -->
-    <div class="blog-posts-container blog-posts-container--hub">
-      {%- comment -%} Pass 1: pinned handles in order {%- endcomment -%}
-      {%- if _pins and _pins.size > 0 -%}
-        {%- for handle in _pins -%}
-          {%- assign h = handle | strip -%}
-          {%- if h != '' and _shown < _take -%}
-            {%- for a in _blog.articles -%}
-              {%- if a.handle == h -%}
-                <div class="blog-post-item">
-                  {%- capture hub_card_body -%}
-                    {%- assign hub_excerpt = a.excerpt_or_content | strip_html -%}
-                    {%- if hub_excerpt != '' -%}
-                      <div class="blog-post-card__excerpt">{{ hub_excerpt | truncate: 140 | escape }}</div>
-                    {%- endif -%}
-                  {%- endcapture -%}
-                  {% render 'nb-hub-article-card', article: a, body: hub_card_body %}
-                </div>
-                {%- assign _picked = _picked | append: a.handle | append: ',' -%}
-                {%- assign _shown = _shown | plus: 1 -%}
-                {%- break -%}
-              {%- endif -%}
-            {%- endfor -%}
-          {%- endif -%}
+      <div class="nb-posts-grid">
+        {%- for article in articles -%}
+          {% render 'nb-article-card', article: article %}
         {%- endfor -%}
-      {%- endif -%}
-
-      {%- comment -%} Pass 2: tag-based top-up (hub:<page.handle>) {%- endcomment -%}
-      {%- if _shown < _take and _hub_tag != blank -%}
-        {%- for a in _blog.articles -%}
-          {%- if _shown < _take -%}
-            {%- unless _picked contains a.handle -%}
-              {%- if a.tags contains _hub_tag -%}
-                <div class="blog-post-item">
-                  {%- capture hub_card_body -%}
-                    {%- assign hub_excerpt = a.excerpt_or_content | strip_html -%}
-                    {%- if hub_excerpt != '' -%}
-                      <div class="blog-post-card__excerpt">{{ hub_excerpt | truncate: 140 | escape }}</div>
-                    {%- endif -%}
-                  {%- endcapture -%}
-                  {% render 'nb-hub-article-card', article: a, body: hub_card_body %}
-                </div>
-                {%- assign _picked = _picked | append: a.handle | append: ',' -%}
-                {%- assign _shown = _shown | plus: 1 -%}
-              {%- endif -%}
-            {%- endunless -%}
-          {%- endif -%}
-        {%- endfor -%}
-      {%- endif -%}
+      </div>
     </div>
   </section>
 {%- elsif request.design_mode -%}


### PR DESCRIPTION
## Summary
- replace the hub’s bespoke markup with the shared related-posts structure and standard article card snippet
- add a reusable `nb-article-card` component plus styling so hub cards mirror the blog layout, spacing, and media aspect ratio
- refresh hub CSS to remove the oversized bubble wrapper and apply the responsive grid used on the journal index

## Testing
- not run (Liquid/CSS changes only)

## Screenshots
- before: _unavailable in containerized theme environment_
- after: _unavailable in containerized theme environment_

Impacted page: https://nibana.com/pages/executive-coaching-services

------
https://chatgpt.com/codex/tasks/task_e_68defa31c9d4833199ed2c075520dc3d