### PR TITLE
Handle blog object handles in related posts hub

### DIFF
--- a/snippets/nb-related-posts-hub.liquid
+++ b/snippets/nb-related-posts-hub.liquid
@@ -1,11 +1,21 @@
 {%- liquid
-  assign _raw_handle = blog_handle | default: '' | strip
   assign _blog = nil
-  if _raw_handle != ''
-    assign _blog = blogs[_raw_handle]
-    if _blog == nil
-      assign _handleized = _raw_handle | handleize
-      assign _blog = blogs[_handleized]
+  assign _raw_handle = ''
+
+  if blog_handle and blog_handle.handle
+    assign _blog = blog_handle
+    assign _raw_handle = blog_handle.handle
+  endif
+
+  if _blog == nil
+    assign _raw_handle = blog_handle | default: '' | strip
+
+    if _raw_handle != ''
+      assign _blog = blogs[_raw_handle]
+      if _blog == nil
+        assign _handleized = _raw_handle | handleize
+        assign _blog = blogs[_handleized]
+      endif
     endif
   endif
 


### PR DESCRIPTION
## Summary
- detect blog reference metafields that already resolve to a blog object
- reuse the resolved blog object while keeping the legacy string fallback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df057fce1c8331a0f1b28a0b019fd9