### PR TITLE
Handle resolved blog drops in related posts snippet

### DIFF
--- a/snippets/nb-related-posts-hub.liquid
+++ b/snippets/nb-related-posts-hub.liquid
@@ -2,7 +2,7 @@
   assign _blog = nil
   assign _raw_handle = ''
 
-  if blog_handle and blog_handle.handle
+  if blog_handle and blog_handle | respond_to: 'handle'
     assign _blog = blog_handle
     assign _raw_handle = blog_handle.handle
   endif


### PR DESCRIPTION
## Summary
- ensure the related posts hub accepts a resolved blog drop by checking for a `handle` method
- retain the legacy string-based lookup as a fallback for manual handles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df09ef28588331b2ea3670fe3c07a6