### PR TITLE
Handle blog handle metafield objects in related posts hub snippet

### DIFF
--- a/snippets/nb-related-posts-hub.liquid
+++ b/snippets/nb-related-posts-hub.liquid
@@ -2,13 +2,14 @@
   assign _blog = nil
   assign _raw_handle = ''
 
-  if blog_handle and blog_handle | respond_to: 'handle'
+  if blog_handle and blog_handle.handle
     assign _blog = blog_handle
     assign _raw_handle = blog_handle.handle
+  else
+    assign _raw_handle = blog_handle | default: '' | strip
   endif
 
   if _blog == nil
-    assign _raw_handle = blog_handle | default: '' | strip
 
     if _raw_handle != ''
       assign _blog = blogs[_raw_handle]


### PR DESCRIPTION
## Summary
- detect when the hub blog metafield provides a full blog object and resolve its handle directly
- fall back to existing handle lookup logic so string values continue to work

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68df0b6529e08331bc658d6a31cc1e37