### PR TITLE
Fix related posts hub blog handle initialization

### DIFF
--- a/snippets/nb-related-posts-hub.liquid
+++ b/snippets/nb-related-posts-hub.liquid
@@ -2,14 +2,15 @@
   assign _blog = nil
   assign _raw_handle = ''
 
-  if blog_handle and blog_handle.handle
-    assign _blog = blog_handle
-    assign _raw_handle = blog_handle.handle
-  else
-    assign _raw_handle = blog_handle | default: '' | strip
+  if blog_handle
+    if blog_handle.handle
+      assign _blog = blog_handle
+      assign _raw_handle = blog_handle.handle
+    endif
   endif
 
   if _blog == nil
+    assign _raw_handle = blog_handle | default: '' | strip
 
     if _raw_handle != ''
       assign _blog = blogs[_raw_handle]


### PR DESCRIPTION
## Summary
- ensure the related posts hub snippet detects object-style blog handles before falling back to strings

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df0cbb32f08331b9bb4aa397ea9b09