### PR TITLE
Guard blog handle resolution

### DIFF
--- a/snippets/nb-related-posts-hub.liquid
+++ b/snippets/nb-related-posts-hub.liquid
@@ -1,12 +1,9 @@
 {%- liquid
   assign _blog = nil
-  assign _raw_handle = ''
 
-  if blog_handle
-    if blog_handle.handle
-      assign _blog = blog_handle
-      assign _raw_handle = blog_handle.handle
-    endif
+  if blog_handle and blog_handle.handle
+    assign _blog = blog_handle
+    assign _raw_handle = blog_handle.handle
   endif
 
   if _blog == nil


### PR DESCRIPTION
## Summary
- retain resolved blog object when seo_hub.blog_handle stores a blog reference
- fall back to string-based blog lookup only when the resolved blog remains nil

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df0e1b5f3c83318ffd91c67f4f4ce5