### PR TITLE
Hub: restore Related posts (render blog-post-card, resolve blog handle, pins→tag→latest, editor debug)

### DIFF
--- a/sections/seo-hub.liquid
+++ b/sections/seo-hub.liquid
@@ -108,15 +108,10 @@
       @media (min-width:1024px){.nb-hub .nb-benefits .nb-method__body ul{grid-template-columns:1fr 1fr 1fr}}
       .nb-hub .nb-benefits .nb-method__body ul li{padding:12px 14px;border-radius:9999px;background:rgba(255,255,255,.6);box-shadow:0 1px 8px rgba(0,0,0,.04)}
 
-      /* Hub: related posts */
-      .nb-hub .nb-related-posts{margin-top:clamp(24px,4vw,48px)}
-      .nb-hub .nb-related-posts .nb-shell{max-width:1200px;margin-inline:auto;padding-inline:16px}
-      .nb-hub .nb-related-posts__header{margin-bottom:clamp(12px,2.5vw,24px)}
-      .nb-hub .nb-related-posts__title{margin:0;font-size:clamp(22px,2.2vw,36px);font-weight:700;letter-spacing:-.02em}
-      .nb-hub .nb-posts-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-6,24px);align-items:start}
-      .nb-hub .nb-related-posts .panel,
-      .nb-hub .nb-related-posts .nb-card,
-      .nb-hub .nb-related-posts .nb-bubble{background:transparent !important;box-shadow:none !important;padding:0 !important;border-radius:0 !important}
+      /* Related posts */
+      .nb-hub .nb-related{margin-top:clamp(24px,4vw,48px)}
+      .nb-hub .nb-related__grid{display:grid;gap:clamp(18px,2.4vw,28px);grid-template-columns:1fr}
+      @media (min-width:900px){.nb-hub .nb-related__grid{grid-template-columns:1fr 1fr}}
 
       /* Trust belt label */
       .nb-hub .nb-trust-eyebrow{margin:18px 0 10px;text-align:center;letter-spacing:.08em;text-transform:uppercase;font-size:.8rem;font-weight:700;opacity:.7}

--- a/snippets/nb-related-posts-hub.liquid
+++ b/snippets/nb-related-posts-hub.liquid
@@ -1,20 +1,11 @@
 {%- liquid
+  assign _raw_handle = blog_handle | default: '' | strip
   assign _blog = nil
-
-  if blog_handle and blog_handle.handle
-    assign _blog = blog_handle
-    assign _raw_handle = blog_handle.handle
-  endif
-
-  if _blog == nil
-    assign _raw_handle = blog_handle | default: '' | strip
-
-    if _raw_handle != ''
-      assign _blog = blogs[_raw_handle]
-      if _blog == nil
-        assign _handleized = _raw_handle | handleize
-        assign _blog = blogs[_handleized]
-      endif
+  if _raw_handle != ''
+    assign _blog = blogs[_raw_handle]
+    if _blog == nil
+      assign _handleized = _raw_handle | handleize
+      assign _blog = blogs[_handleized]
     endif
   endif
 
@@ -22,6 +13,7 @@
   assign _shown = 0
   assign _picked = ''
   assign _hub_tag = hub_tag | default: ''
+
   assign _pins = blank
   if hub and hub.manual_related_handles and hub.manual_related_handles.value
     assign _pins = hub.manual_related_handles.value
@@ -34,84 +26,84 @@
   if _heading == ''
     assign _heading = 'From the Nibana Journal'
   endif
-
-  assign articles = '' | split: ''
-  assign _articles_count = 0
-  if _blog
-    assign _articles_count = _blog.articles_count | plus: 0
-  endif
-
-  if _blog and _articles_count > 0
-    if _pins and _pins.size > 0
-      for handle in _pins
-        if _shown >= _take
-          break
-        endif
-
-        assign pin_article = nil
-        assign pin_handle = ''
-
-        if handle.handle
-          assign pin_article = handle
-          assign pin_handle = handle.handle
-        else
-          assign pin_handle = handle | strip
-
-          if pin_handle != ''
-            for a in _blog.articles
-              if a.handle == pin_handle
-                assign pin_article = a
-                break
-              endif
-            endfor
-          endif
-        endif
-
-        if pin_article and pin_handle != ''
-          unless _picked contains pin_handle
-            assign articles = articles | push: pin_article
-            assign _picked = _picked | append: pin_handle | append: ','
-            assign _shown = _shown | plus: 1
-          endunless
-        endif
-      endfor
-    endif
-
-    if _shown < _take and _hub_tag != blank
-      for a in _blog.articles
-        if _shown < _take
-          unless _picked contains a.handle
-            if a.tags contains _hub_tag
-              assign articles = articles | push: a
-              assign _picked = _picked | append: a.handle | append: ','
-              assign _shown = _shown | plus: 1
-            endif
-          endunless
-        endif
-      endfor
-    endif
-  endif
-
-  assign _selected_count = articles | size
 -%}
-{%- if _selected_count > 0 -%}
-  <section class="nb-related-posts">
-    <div class="nb-shell">
-      <header class="nb-related-posts__header">
-        <h2 class="nb-related-posts__title">{{ _heading }}</h2>
-      </header>
+{%- if _blog -%}{%- assign _articles_count = _blog.articles_count | plus: 0 -%}{%- endif -%}
 
-      <div class="nb-posts-grid">
-        {%- for article in articles -%}
-          {% render 'nb-article-card', article: article %}
+{%- if _blog and _articles_count > 0 -%}
+  <section class="nb-related nb-related--xl">
+    <h2 class="h2 nb-related__heading">{{ _heading }}</h2>
+
+    <div class="nb-related__grid">
+      {%- comment -%} Pass 1 — Pinned handles in exact order {%- endcomment -%}
+      {%- if _pins and _pins.size > 0 -%}
+        {%- for handle in _pins -%}
+          {%- assign h = handle | strip -%}
+          {%- if h != '' and _shown < _take -%}
+            {%- for a in _blog.articles -%}
+              {%- if a.handle == h -%}
+                <div class="nb-related__item">
+                  {% render 'blog-post-card', article: a %}
+                </div>
+                {%- assign _picked = _picked | append: a.handle | append: ',' -%}
+                {%- assign _shown = _shown | plus: 1 -%}
+                {%- break -%}
+              {%- endif -%}
+            {%- endfor -%}
+          {%- endif -%}
         {%- endfor -%}
-      </div>
+      {%- endif -%}
+
+      {%- comment -%} Pass 2 — Tag-based top-up (hub:<page.handle>) {%- endcomment -%}
+      {%- if _shown < _take and _hub_tag != blank -%}
+        {%- for a in _blog.articles -%}
+          {%- if _shown < _take -%}
+            {%- unless _picked contains a.handle -%}
+              {%- if a.tags contains _hub_tag -%}
+                <div class="nb-related__item">
+                  {% render 'blog-post-card', article: a %}
+                </div>
+                {%- assign _picked = _picked | append: a.handle | append: ',' -%}
+                {%- assign _shown = _shown | plus: 1 -%}
+              {%- endif -%}
+            {%- endunless -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- endif -%}
+
+      {%- comment -%} Pass 3 — Fallback to latest posts (avoid empty state) {%- endcomment -%}
+      {%- if _shown < _take -%}
+        {%- for a in _blog.articles -%}
+          {%- if _shown < _take -%}
+            {%- unless _picked contains a.handle -%}
+              <div class="nb-related__item">
+                {% render 'blog-post-card', article: a %}
+              </div>
+              {%- assign _picked = _picked | append: a.handle | append: ',' -%}
+              {%- assign _shown = _shown | plus: 1 -%}
+            {%- endunless -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- endif -%}
     </div>
+
+    {%- if request.design_mode -%}
+      <div class="nb-shell" style="margin:8px 0 0;">
+        <div class="nb-tray" style="padding:10px 12px; border-radius:12px; background:var(--oc-surface);">
+          <div class="rte">
+            <strong>Hub debug:</strong>
+            Blog input: <code>{{ _raw_handle }}</code> · Resolved: <code>{{ _handleized | default: _raw_handle }}</code> ·
+            Tag: <code>{{ _hub_tag }}</code> · Shown: <strong>{{ _shown }}</strong> / {{ _take }}
+          </div>
+        </div>
+      </div>
+    {%- endif -%}
   </section>
 {%- elsif request.design_mode -%}
   <div class="nb-shell" style="margin:8px 0 0;">
     <div class="nb-tray" style="padding:10px 12px; border-radius:12px; background:var(--oc-surface);">
-      <div class="rte"><strong>Hub notice:</strong> <code>seo_hub.blog_handle</code> should be the blog <em>handle</em> (e.g., <code>nibana-journal</code>), not the title.</div>
+      <div class="rte">
+        <strong>Hub notice:</strong> <code>seo_hub.blog_handle</code> should be the blog <em>handle</em> (e.g., <code>news</code>), not the title.
+      </div>
     </div>
   </div>
 {%- endif -%}


### PR DESCRIPTION
## Summary
- replace the hub related posts snippet to render blog-post-card entries with pin, tag, and latest fallbacks plus editor debug output
- adjust SEO Hub section styles to align the layout with the new related posts grid

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df8a49b9508331948b09c3143f2bd1