### PR TITLE
SEO Hub cleanup: remove unused XL card snippet; simplify CSS; 3-up related grid

### DIFF
--- a/sections/seo-hub.liquid
+++ b/sections/seo-hub.liquid
@@ -110,8 +110,12 @@
 
       /* Related posts */
       .nb-hub .nb-related{margin-top:clamp(24px,4vw,48px)}
+      /* Related posts — grid (3-up on wide screens) */
       .nb-hub .nb-related__grid{display:grid;gap:clamp(18px,2.4vw,28px);grid-template-columns:1fr}
       @media (min-width:900px){.nb-hub .nb-related__grid{grid-template-columns:1fr 1fr}}
+      @media (min-width:1280px){.nb-hub .nb-related__grid{grid-template-columns:1fr 1fr 1fr}}
+      /* keep heading centering from earlier */
+      .nb-hub .nb-related__heading{margin:0 0 18px;text-align:center}
 
       /* Trust belt label */
       .nb-hub .nb-trust-eyebrow{margin:18px 0 10px;text-align:center;letter-spacing:.08em;text-transform:uppercase;font-size:.8rem;font-weight:700;opacity:.7}


### PR DESCRIPTION
## Summary
- update the SEO Hub related posts grid styling to support 1/2/3-column breakpoints
- keep the related heading centered while deferring card visuals to the shared blog card snippet

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df8c4462688331be65c3290d8e1576