### PR TITLE
Hub: wrap Related posts in nb-shell for centered alignment with panels

### DIFF
--- a/snippets/nb-related-posts-hub.liquid
+++ b/snippets/nb-related-posts-hub.liquid
@@ -31,79 +31,77 @@
 
 {%- if _blog and _articles_count > 0 -%}
   <section class="nb-related nb-related--xl">
-    <h2 class="h2 nb-related__heading">{{ _heading }}</h2>
+    <div class="nb-shell">
+      <h2 class="h2 nb-related__heading">{{ _heading }}</h2>
 
-    <div class="nb-related__grid">
-      {%- comment -%} Pass 1 — Pinned handles in exact order {%- endcomment -%}
-      {%- if _pins and _pins.size > 0 -%}
-        {%- for handle in _pins -%}
-          {%- assign h = handle | strip -%}
-          {%- if h != '' and _shown < _take -%}
-            {%- for a in _blog.articles -%}
-              {%- if a.handle == h -%}
+      <div class="nb-related__grid">
+        {%- comment -%} Pass 1 — pinned handles in order {%- endcomment -%}
+        {%- if _pins and _pins.size > 0 -%}
+          {%- for handle in _pins -%}
+            {%- assign h = handle | strip -%}
+            {%- if h != '' and _shown < _take -%}
+              {%- for a in _blog.articles -%}
+                {%- if a.handle == h -%}
+                  <div class="nb-related__item">
+                    {% render 'blog-post-card', article: a %}
+                  </div>
+                  {%- assign _picked = _picked | append: a.handle | append: ',' -%}
+                  {%- assign _shown = _shown | plus: 1 -%}
+                  {%- break -%}
+                {%- endif -%}
+              {%- endfor -%}
+            {%- endif -%}
+          {%- endfor -%}
+        {%- endif -%}
+
+        {%- comment -%} Pass 2 — tag-based top-up (hub:<page.handle>) {%- endcomment -%}
+        {%- if _shown < _take and _hub_tag != blank -%}
+          {%- for a in _blog.articles -%}
+            {%- if _shown < _take -%}
+              {%- unless _picked contains a.handle -%}
+                {%- if a.tags contains _hub_tag -%}
+                  <div class="nb-related__item">
+                    {% render 'blog-post-card', article: a %}
+                  </div>
+                  {%- assign _picked = _picked | append: a.handle | append: ',' -%}
+                  {%- assign _shown = _shown | plus: 1 -%}
+                {%- endif -%}
+              {%- endunless -%}
+            {%- endif -%}
+          {%- endfor -%}
+        {%- endif -%}
+
+        {%- comment -%} Pass 3 — latest posts fallback {%- endcomment -%}
+        {%- if _shown < _take -%}
+          {%- for a in _blog.articles -%}
+            {%- if _shown < _take -%}
+              {%- unless _picked contains a.handle -%}
                 <div class="nb-related__item">
                   {% render 'blog-post-card', article: a %}
                 </div>
                 {%- assign _picked = _picked | append: a.handle | append: ',' -%}
                 {%- assign _shown = _shown | plus: 1 -%}
-                {%- break -%}
-              {%- endif -%}
-            {%- endfor -%}
-          {%- endif -%}
-        {%- endfor -%}
-      {%- endif -%}
+              {%- endunless -%}
+            {%- endif -%}
+          {%- endfor -%}
+        {%- endif -%}
+      </div>
 
-      {%- comment -%} Pass 2 — Tag-based top-up (hub:<page.handle>) {%- endcomment -%}
-      {%- if _shown < _take and _hub_tag != blank -%}
-        {%- for a in _blog.articles -%}
-          {%- if _shown < _take -%}
-            {%- unless _picked contains a.handle -%}
-              {%- if a.tags contains _hub_tag -%}
-                <div class="nb-related__item">
-                  {% render 'blog-post-card', article: a %}
-                </div>
-                {%- assign _picked = _picked | append: a.handle | append: ',' -%}
-                {%- assign _shown = _shown | plus: 1 -%}
-              {%- endif -%}
-            {%- endunless -%}
-          {%- endif -%}
-        {%- endfor -%}
-      {%- endif -%}
-
-      {%- comment -%} Pass 3 — Fallback to latest posts (avoid empty state) {%- endcomment -%}
-      {%- if _shown < _take -%}
-        {%- for a in _blog.articles -%}
-          {%- if _shown < _take -%}
-            {%- unless _picked contains a.handle -%}
-              <div class="nb-related__item">
-                {% render 'blog-post-card', article: a %}
-              </div>
-              {%- assign _picked = _picked | append: a.handle | append: ',' -%}
-              {%- assign _shown = _shown | plus: 1 -%}
-            {%- endunless -%}
-          {%- endif -%}
-        {%- endfor -%}
-      {%- endif -%}
-    </div>
-
-    {%- if request.design_mode -%}
-      <div class="nb-shell" style="margin:8px 0 0;">
-        <div class="nb-tray" style="padding:10px 12px; border-radius:12px; background:var(--oc-surface);">
+      {%- if request.design_mode -%}
+        <div class="nb-tray" style="margin-top:8px; padding:10px 12px; border-radius:12px; background:var(--oc-surface);">
           <div class="rte">
             <strong>Hub debug:</strong>
             Blog input: <code>{{ _raw_handle }}</code> · Resolved: <code>{{ _handleized | default: _raw_handle }}</code> ·
             Tag: <code>{{ _hub_tag }}</code> · Shown: <strong>{{ _shown }}</strong> / {{ _take }}
           </div>
         </div>
-      </div>
-    {%- endif -%}
+      {%- endif -%}
+    </div>
   </section>
-{%- elsif request.design_mode -%}
+{%- elif request.design_mode -%}
   <div class="nb-shell" style="margin:8px 0 0;">
     <div class="nb-tray" style="padding:10px 12px; border-radius:12px; background:var(--oc-surface);">
-      <div class="rte">
-        <strong>Hub notice:</strong> <code>seo_hub.blog_handle</code> should be the blog <em>handle</em> (e.g., <code>news</code>), not the title.
-      </div>
+      <div class="rte"><strong>Hub notice:</strong> <code>seo_hub.blog_handle</code> should be the blog <em>handle</em> (e.g., <code>news</code>), not the title.</div>
     </div>
   </div>
 {%- endif -%}


### PR DESCRIPTION
## Summary
- wrap the hub related posts heading and grid in an nb-shell so the cards align with surrounding panels
- keep the Theme Editor debug tray inside the shell with updated margin

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df8de31a448331a45821acd94f665d