### PR TITLE
Adjust related posts grid card width

### DIFF
--- a/sections/seo-hub.liquid
+++ b/sections/seo-hub.liquid
@@ -111,7 +111,7 @@
       /* Related posts */
       .nb-hub .nb-related{margin-top:clamp(24px,4vw,48px)}
       /* Related posts — grid (3-up on wide screens) */
-      .nb-hub .nb-related__grid{display:grid;gap:clamp(18px,2.4vw,28px);grid-template-columns:repeat(auto-fit,minmax(min(320px,100%),1fr))}
+      .nb-hub .nb-related__grid{display:grid;gap:clamp(18px,2.4vw,28px);grid-template-columns:repeat(auto-fit,minmax(min(300px,100%),1fr))}
       /* keep heading centering from earlier */
       .nb-hub .nb-related__heading{margin:0 0 18px;text-align:center}
 


### PR DESCRIPTION
## Summary
- reduce the related posts grid minimum track width to allow three cards within the padded shell

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df95158c6483318703333cc6e741b2