### PR TITLE
Adjust SEO hub related shell layout

### DIFF
--- a/sections/seo-hub.liquid
+++ b/sections/seo-hub.liquid
@@ -87,6 +87,7 @@
     <style>
       /* Shell & rhythm */
       .nb-hub .nb-shell{max-width:var(--narrow-page-width,1120px);margin:0 auto;padding:0 20px}
+      .nb-hub .nb-related>.nb-shell{padding-inline:0;max-width:100%}
       .nb-hub .nb-hero{margin:clamp(28px,6vw,72px) 0}
       .nb-hub .nb-tray{background:var(--nb-mist);border-radius:20px;padding:clamp(22px,3vw,34px);box-shadow:0 10px 28px rgba(0,0,0,.06)}
       .nb-hub .nb-intro{margin:clamp(18px,3vw,32px) 0}


### PR DESCRIPTION
## Summary
- remove the extra inline padding on the related posts shell so the cards align with other trays on the SEO hub page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfa83c95a08331aae38830300bdc84