### PR TITLE
SEO Hub: center Related posts and match panel width; robust 3-up grid

### DIFF
--- a/sections/seo-hub.liquid
+++ b/sections/seo-hub.liquid
@@ -113,10 +113,15 @@
 
       /* Related posts */
       .nb-hub .nb-related{margin-top:clamp(24px,4vw,48px)}
-      /* Related posts — grid (3-up on wide screens) */
-      .nb-hub .nb-related__grid{display:grid;gap:clamp(18px,2.4vw,28px);grid-template-columns:1fr}
-      @media (min-width:900px){.nb-hub .nb-related__grid{grid-template-columns:1fr 1fr}}
-      @media (min-width:1280px){.nb-hub .nb-related__grid{grid-template-columns:1fr 1fr 1fr}}
+      /* Related posts — centered grid matching panel width */
+      .nb-hub .nb-related__grid{display:grid;gap:clamp(18px,2.4vw,28px);grid-template-columns:repeat(1, minmax(0, 1fr));justify-content:center}
+      @media (min-width:900px){.nb-hub .nb-related__grid{grid-template-columns:repeat(2, minmax(0, 1fr))}}
+      @media (min-width:1200px){.nb-hub .nb-related__grid{grid-template-columns:repeat(3, minmax(0, 1fr))}}
+      /* Ensure each card fills its grid track */
+      .nb-hub .nb-related__item{width:100%}
+      .nb-hub .nb-related__item>*{width:100%;display:block}
+
+      /* Keep heading centred and aligned with panels */
       .nb-hub .nb-related__heading{margin:0 0 18px;text-align:center}
 
       /* Trust belt label */

--- a/snippets/nb-related-posts-hub.liquid
+++ b/snippets/nb-related-posts-hub.liquid
@@ -31,7 +31,7 @@
 
 {%- if _blog and _articles_count > 0 -%}
   <section class="nb-related nb-related--xl">
-    <div class="nb-shell nb-shell--wide">
+    <div class="nb-shell">
       <h2 class="h2 nb-related__heading">{{ _heading }}</h2>
 
       <div class="nb-related__grid">


### PR DESCRIPTION
## Summary
- revert the related posts shell wrapper to the standard width container
- update the hub related posts grid to center cards and ensure responsive 1/2/3-up layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfab8f21fc8331a62da229b85216ab