### PR TITLE
SEO Hub: stretch blog cards to fill 3-up grid; remove excess side gutters

### DIFF
--- a/sections/seo-hub.liquid
+++ b/sections/seo-hub.liquid
@@ -113,16 +113,24 @@
 
       /* Related posts */
       .nb-hub .nb-related{margin-top:clamp(24px,4vw,48px)}
-      /* Related posts — centered grid matching panel width */
-      .nb-hub .nb-related__grid{display:grid;gap:clamp(18px,2.4vw,28px);grid-template-columns:repeat(1, minmax(0, 1fr));justify-content:center}
+      /* Related posts — centered heading, cards fill grid tracks */
+      .nb-hub .nb-related__heading{margin:0 0 18px;text-align:center}
+
+      /* Grid: 1 / 2 / 3 columns */
+      .nb-hub .nb-related__grid{display:grid;gap:clamp(18px,2.4vw,28px);grid-template-columns:repeat(1, minmax(0, 1fr));justify-content:normal;justify-items:stretch;align-items:stretch}
       @media (min-width:900px){.nb-hub .nb-related__grid{grid-template-columns:repeat(2, minmax(0, 1fr))}}
       @media (min-width:1200px){.nb-hub .nb-related__grid{grid-template-columns:repeat(3, minmax(0, 1fr))}}
-      /* Ensure each card fills its grid track */
-      .nb-hub .nb-related__item{width:100%}
-      .nb-hub .nb-related__item>*{width:100%;display:block}
 
-      /* Keep heading centred and aligned with panels */
-      .nb-hub .nb-related__heading{margin:0 0 18px;text-align:center}
+      /* Force blog cards to use full track width (override their internal max-width/margins) */
+      .nb-hub .nb-related__item{width:100%}
+      .nb-hub .nb-related__item>*{width:100% !important;max-width:none !important;margin:0 !important;display:block}
+      /* A few likely classnames used by the blog card; safe to include even if not present */
+      .nb-hub .nb-related__item .blog-post-card,
+      .nb-hub .nb-related__item .blog-post,
+      .nb-hub .nb-related__item article{width:100% !important;max-width:none !important;margin:0 !important}
+
+      /* Ensure media spans full card width for visual balance */
+      .nb-hub .nb-related__item img{width:100%;height:auto;display:block}
 
       /* Trust belt label */
       .nb-hub .nb-trust-eyebrow{margin:18px 0 10px;text-align:center;letter-spacing:.08em;text-transform:uppercase;font-size:.8rem;font-weight:700;opacity:.7}


### PR DESCRIPTION
## Summary
- update SEO Hub related posts grid to stretch across the shell and fill available columns
- ensure blog cards and media span full track width without internal max-width constraints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfb826db048331a6473428bb766226