### PR TITLE
SEO Hub: add subtle atmospheric overlay to Hero (radial glow + grain)

### DIFF
--- a/sections/seo-hub.liquid
+++ b/sections/seo-hub.liquid
@@ -87,7 +87,13 @@
     <style>
       /* Shell & rhythm (keep panels full-bleed-safe) */
       .nb-hub .nb-shell{max-width:var(--narrow-page-width,1120px);margin:0 auto;padding:0 20px}
-      .nb-hub .nb-hero{margin:clamp(36px,7vw,88px) 0 clamp(14px,3.5vw,26px)}
+      /* HERO host: allow overlay layers to sit behind text safely */
+      .nb-hub .nb-hero{
+        margin:clamp(36px,7vw,88px) 0 clamp(14px,3.5vw,26px);
+        position:relative;
+        isolation:isolate; /* keeps blend/overlays contained */
+      }
+      .nb-hub .nb-hero > *{ position:relative; z-index:1; } /* keep text above overlays */
       .nb-hub .nb-tray{background:var(--nb-mist);border-radius:22px;padding:clamp(24px,3.2vw,36px);box-shadow:0 10px 28px rgba(0,0,0,.06)}
 
       /* HERO — eyebrow, H1 rhythm, deck as lead */
@@ -104,6 +110,30 @@
       .nb-hub .nb-hero h1,
       .nb-hub .nb-hero .h1{margin:0 0 8px;line-height:1.22;max-width:20ch}
       .nb-hub .lead{font-weight:500;line-height:1.6;max-width:65ch}
+
+      /* HERO atmospheric overlay (radial glow + soft grain) */
+      .nb-hub .nb-hero::before{
+        content:"";
+        position:absolute; inset:0;
+        pointer-events:none; z-index:0;
+        /* subtle dual radial washes, tuned to brand accent */
+        --hero-accent: var(--color-accent, #0F5B59);
+        background:
+          radial-gradient(1200px 520px at 70% -10%, color-mix(in oklab, var(--hero-accent), #ffffff 88%) 0%, transparent 60%),
+          radial-gradient(900px 420px at 0% 8%, color-mix(in oklab, var(--hero-accent), #ffffff 92%) 0%, transparent 62%);
+        opacity:.22; /* keep very subtle */
+      }
+
+      /* ultra-light grain on top for texture */
+      .nb-hub .nb-hero::after{
+        content:"";
+        position:absolute; inset:0;
+        pointer-events:none; z-index:0;
+        mix-blend-mode:soft-light;
+        opacity:.05;
+        background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.8' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='.85'/%3E%3C/svg%3E");
+        background-size:160px 160px;
+      }
 
       /* INTRO tray — editorial measure + subtle vellum top highlight */
       .nb-hub .nb-intro{margin:clamp(18px,3vw,32px) 0}


### PR DESCRIPTION
## Summary
- prepare the SEO Hub hero container to host overlay layers safely
- add subtle radial glow and grain overlays driven by the accent color

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfcdbd83ec8331bc7fdca63adb33ba