### PR TITLE
Centralise canonical in meta-tags; remove Hub Service schema; add WebPage (Hub) + Breadcrumbs (Service); add gentle Service→Hub link

### DIFF
--- a/sections/coaching-service.liquid
+++ b/sections/coaching-service.liquid
@@ -1440,6 +1440,18 @@
 </script>
 {%- endif -%}
 
+{%- comment -%} JSON-LD: Breadcrumb for the service page {%- endcomment -%}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": {{ routes.root_url | prepend: request.origin | json }} },
+    { "@type": "ListItem", "position": 2, "name": {{ page.title | json }}, "item": {{ request.origin | append: request.path | json }} }
+  ]
+}
+</script>
+
     <script>
       (function(){
         var root = document.getElementById('nb-faq-{{ section.id }}-svc');
@@ -1454,8 +1466,13 @@
   {%- endif -%}
 
   <!-- Bottom CTA centered (flex wrapper) -->
-<div style="padding:10px 0 24px; display:flex; justify-content:center;">
-  <a class="nb-cta nb-cta--xl" href="{{ btn_href }}" data-cta="book-call">{{ btn_label }}</a>
+<div style="padding:10px 0 24px;">
+  <p class="nb-learn" style="text-align:center; margin:0 0 10px;">
+    <a class="nb-link" href="/pages/executive-coaching-services">Learn about executive coaching</a>
+  </p>
+  <div style="display:flex; justify-content:center;">
+    <a class="nb-cta nb-cta--xl" href="{{ btn_href }}" data-cta="book-call">{{ btn_label }}</a>
+  </div>
 </div>
 
     </div>

--- a/sections/seo-hub.liquid
+++ b/sections/seo-hub.liquid
@@ -16,10 +16,6 @@
   endif
 -%}
 
-{%- if page.metafields.custom.canonical_url and page.metafields.custom.canonical_url != blank -%}
-  <link rel="canonical" href="{{ page.metafields.custom.canonical_url }}" />
-{%- endif -%}
-
 {%- if hub -%}
   {%- liquid
     assign hub_h1      = hub.h1_override.value | default: page.title
@@ -29,7 +25,6 @@
     assign hub_cta_h   = hub.cta_headline.value | default: ''
     assign hub_cta_txt = hub.cta_text.value | default: 'Book a discovery call'
     assign hub_cta_url = hub.cta_url.value  | default: '/pages/book-a-call'
-    assign hub_schema  = hub.schema_type.value | default: 'Service'
     assign hub_show_faq = hub.show_faq.value | default: false
     assign hub_show_trust = hub.show_trustbelt.value | default: true
     assign hub_trust_variant = hub.logo_belt_variant.value | default: 'marquee'
@@ -354,7 +349,7 @@
     </div>
   </section>
 
-  {%- comment -%} JSON-LD: Breadcrumb + optional Service {%- endcomment -%}
+  {%- comment -%} JSON-LD: Breadcrumb {%- endcomment -%}
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -365,18 +360,17 @@
     ]
   }
   </script>
-  {%- if hub_schema == 'Service' -%}
+  {%- comment -%} JSON-LD: WebPage (informational hub) {%- endcomment -%}
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "Service",
-    "@id": {{ request.origin | append: request.path | append: '#service' | json }},
+    "@type": "WebPage",
+    "@id": {{ request.origin | append: request.path | append: "#webpage" | json }},
+    "url": {{ request.origin | append: request.path | json }},
     "name": {{ hub_h1 | json }},
-    "serviceType": "Executive Coaching",
-    "provider": { "@type": "Organization", "name": {{ shop.name | json }} }
+    "description": {{ hub_deck | strip_html | strip | json }}
   }
   </script>
-  {%- endif -%}
 {%- else -%}
   {%- if request.design_mode -%}
     <div class="nb-shell" style="margin:8px 0 0;">

--- a/snippets/meta-tags.liquid
+++ b/snippets/meta-tags.liquid
@@ -108,10 +108,12 @@
   {%- unless page_title contains shop.name %} &ndash; {{ shop.name }}{% endunless -%}
 </title>
 
-<link
-  rel="canonical"
-  href="{{ canonical_url }}"
->
+{%- comment -%} Canonical: prefer page metafield; else Shopify default {%- endcomment -%}
+{%- if request.page_type == 'page' and page and page.metafields.custom.canonical_url and page.metafields.custom.canonical_url != blank -%}
+  <link rel="canonical" href="{{ page.metafields.custom.canonical_url | escape }}">
+{%- else -%}
+  <link rel="canonical" href="{{ canonical_url | escape }}">
+{%- endif -%}
 
 {% if page_description %}
   <meta


### PR DESCRIPTION
## Summary
- centralise canonical handling in the shared meta-tags snippet with support for a page metafield override
- remove the Hub-level canonical and Service schema, replacing it with WebPage JSON-LD alongside the existing breadcrumb
- add BreadcrumbList JSON-LD to the service template and include a soft editorial link back to the Hub near the CTA

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dfd6f34ed48331882889f9a51d42eb