### PR TITLE
Remove Service→Hub editorial link from coaching-service.liquid

### DIFF
--- a/sections/coaching-service.liquid
+++ b/sections/coaching-service.liquid
@@ -1467,9 +1467,6 @@
 
   <!-- Bottom CTA centered (flex wrapper) -->
 <div style="padding:10px 0 24px;">
-  <p class="nb-learn" style="text-align:center; margin:0 0 10px;">
-    <a class="nb-link" href="/pages/executive-coaching-services">Learn about executive coaching</a>
-  </p>
   <div style="display:flex; justify-content:center;">
     <a class="nb-cta nb-cta--xl" href="{{ btn_href }}" data-cta="book-call">{{ btn_label }}</a>
   </div>


### PR DESCRIPTION
## Summary
- remove the extra Learn about executive coaching link from the bottom CTA on service pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfefb2c1608331adbc1aa6b5cb7021