### PR TITLE
Remove canonical tag from snippets/nb-surge-meta.liquid; meta-tags.liquid remains sole source of truth

### DIFF
--- a/snippets/nb-surge-meta.liquid
+++ b/snippets/nb-surge-meta.liquid
@@ -28,5 +28,4 @@
   <meta name="twitter:title" content="{{ og_title | escape }}">
   <meta name="twitter:description" content="{{ og_desc | escape }}">
   <meta name="twitter:image" content="{{ og_img }}">
-  <link rel="canonical" href="{{ request.origin }}{{ request.path }}">
 {% endif %}


### PR DESCRIPTION
## Summary
- remove the canonical link output from `snippets/nb-surge-meta.liquid` so `meta-tags.liquid` remains the only canonical source

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0012da1fc83319cbc061e4ef075ac