### PR TITLE
Add pillar page CTA to shared Performance-to-Presence widget

### DIFF
--- a/sections/coaching-service.liquid
+++ b/sections/coaching-service.liquid
@@ -1121,6 +1121,19 @@
 
   /* General RTE tweaks inside the tray */
   .nb-method__rte p{ color:var(--nb-muted); line-height:1.65; }
+
+  .nb-method__learn-more{
+    margin-top: clamp(14px, 2.4vw, 20px);
+  }
+  .nb-method__learn-link{
+    font-weight: 700;
+    color: var(--m-accent);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  .nb-method__learn-link:hover{
+    color: color-mix(in oklab, var(--m-accent), #000 14%);
+  }
 </style>
 
 <section class="nb-method-lite {{ method_tone_class }}">
@@ -1159,6 +1172,12 @@
           <p>Straight, respectful conversations. No fluff. We go at the pace of truth—and we make room for play and mystery along the way.</p>
         </div>
       {%- endif -%}
+
+      <p class="nb-method__learn-more">
+        <a class="nb-method__learn-link" href="/pages/the-performance-to-presence-method">
+          Learn more about the Performance to Presence Method
+        </a>
+      </p>
 
       <!-- Mid-page CTA (below Method tray) -->
       <div class="nb-midcta nb-midcta--method">
@@ -1508,7 +1527,6 @@
   ]
 }
 {% endschema %}
-
 
 
 


### PR DESCRIPTION
### Motivation
- Add a clear call-to-action from the shared Performance to Presence widget so visitors can click through to the pillar page at `/pages/the-performance-to-presence-method`, while keeping the update single-source so it appears across all service pages.

### Description
- Inserted a “Learn more about the Performance to Presence Method” link and wrapper markup into `sections/coaching-service.liquid` and added scoped styles `.nb-method__learn-more` and `.nb-method__learn-link` for visual consistency.
- Made the change in the single shared `coaching-service` section used by service pages so no individual page templates were modified.
- The CTA link target is `/pages/the-performance-to-presence-method` and styling is localized to avoid affecting other components.

### Testing
- Verified the new link and classes exist in `sections/coaching-service.liquid` using `rg` text searches which succeeded.
- Confirmed `templates/page.coaching-service.json` references the shared `coaching-service` section with an `rg` search to ensure the single-source update will propagate to service pages.
- Attempted an automated Playwright screenshot to visually validate the change but it failed because no local preview server was available (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b001b5e4b083319b0905ef709c66b0)